### PR TITLE
Clarify AI commit attribution support and add trailer-based time-to-merge metrics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,9 +7,13 @@ Custom plugins are used and supported by GitHub pages.  This website uses the be
 
 Admonition syntax should follow styling for jekyll-gfm-admonitions
 
-### Page conventions
+### Page Edit Conventions
 
 When editing a content page, update its "Last updated" date (e.g. `*Last updated: <Month D, YYYY>*` near the top) to the current date to reflect the change.
+When editing a page, reread the page if we are changing logic as this may impact other sections of the page.
 
 ### Output
 - Be concise and to the point. Avoid unnecessary words or phrases that do not add value to the content. Focus on delivering clear and direct information to the reader.
+- Avoid repetition. Do not repeat the same information multiple times in different ways. Instead, present the information once in a clear and concise manner.
+- Use simple and straightforward language that is easy to understand. Avoid complex words or jargon that may confuse the reader.
+- Be specific. Provide specific details and examples to support your points.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,3 +10,6 @@ Admonition syntax should follow styling for jekyll-gfm-admonitions
 ### Page conventions
 
 When editing a content page, update its "Last updated" date (e.g. `*Last updated: <Month D, YYYY>*` near the top) to the current date to reflect the change.
+
+### Output
+- Be concise and to the point. Avoid unnecessary words or phrases that do not add value to the content. Focus on delivering clear and direct information to the reader.

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: GitHub Copilot Adoption Resources
-description: "Curated resources for rolling out GitHub Copilot at scale — with links to official documentation and unique cost management and user management guides"
+description: "Guides for cost management, AI commit attribution, and OpenTelemetry monitoring — plus curated links to official Copilot rollout documentation"
 theme: jekyll-theme-cayman
 baseurl: "/copilot-adoption"
 url: "https://samqbush.github.io"

--- a/ai-commit-attribution.md
+++ b/ai-commit-attribution.md
@@ -1,56 +1,150 @@
 ---
 layout: default
-title: AI Commit Attribution — GHES Runbook
+title: Measuring AI in Pull Requests (Not Lines of Code)
 toc: true
 ---
 
-# AI Commit Attribution — GHES Runbook
+# Measuring AI in Pull Requests (Not Lines of Code)
 {:.no_toc}
 
 *Last updated: June 19, 2026*
 
 
-How to track which Pull Requests contain AI-authored commits on GitHub Enterprise Server, where Cloud/EMU-only PR metrics are unavailable.
+A practical way to answer "how much are we using AI?" by measuring AI's contribution to Pull Requests instead of counting lines of code.
 
 ---
 
-## Why This Matters
+## The Problem: The Wrong Question
 
-GitHub Enterprise Cloud exposes native API metrics for AI-attributed PRs — fields like `total_merged_created_by_copilot` in the [Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics). GHES customers don't have access to these metrics.
+A leader reads that "47% of our code is written by AI" and asks the Copilot admin to prove it. The admin opens the Copilot dashboard, finds a lines-suggested or lines-accepted number, and tries to turn it into a percentage of the codebase.
 
-However, the underlying mechanism is portable: AI tools add a `Co-authored-by` [trailer](https://docs.github.com/en/enterprise-cloud@latest/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) to git commit messages. This is a standard Git feature that works on any platform. If you make sure these trailers land on commits and then query for them, you get equivalent visibility on GHES.
+That number does not mean what people think it means. Lines of code is a bad unit for this question:
+
+- **Accepted suggestions are not kept code.** A developer can accept an inline completion, then rewrite or delete it before committing. The dashboard still counts the acceptance.
+- **Lines are not value.** A 200-line generated boilerplate file and a 5-line bug fix that saves the weekend are not comparable, but LoC treats the big file as 40x more "AI."
+- **It rewards the wrong behavior.** Optimizing for "lines written by AI" pushes teams toward verbose, generated code, which is the opposite of what you want.
+- **It is not auditable.** There is no way to point at a specific commit and say "this line was AI and that one was not."
+
+So when a leader asks "how much are we using AI?", counting lines sends you down a path that produces a number you cannot defend.
+
+## The Better Question: AI Leverage
+
+GitHub's [Engineering System Success Playbook](https://github.com/resources/insights/engineering-system-success-playbook) (ESSP) frames the useful metric as **AI leverage**: the share of merged Pull Requests that involved AI. The [Well-Architected Framework](https://wellarchitected.github.com/library/productivity/recommendations/engineering-system-metrics/) summarizes the same idea.
+
+The PR is the right unit because it is the unit of shipped work. A PR got reviewed, merged, and went to production. Ask "what percentage of our merged PRs had AI involved?" and you get a number you can actually defend: you can list the exact PRs behind it, and it does not lurch around just because someone generated one big boilerplate file. It tracks AI's reach into real output instead of counting keystrokes.
+
+This guide shows how to measure AI leverage across the Copilot features your developers actually use.
 
 ---
 
-## Tool Landscape: What Tags Commits Today?
+## How AI Shows Up in a PR
 
-| Tool | Adds trailer by default? | Trailer format | Source |
-|---|---|---|---|
-| **Copilot CLI** | ✅ Yes | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` | Built into CLI system prompt |
-| **VS Code Agent Mode** | ❌ No (opt-in) | `Co-authored-by: Copilot <copilot@github.com>` | Was default in [v1.118](https://code.visualstudio.com/updates/v1_118) (April 2026), [reverted in v1.119](https://github.com/microsoft/vscode/pull/310226) after community backlash (372 👎). Opt-in via `git.addAICoAuthor` setting. |
-| **Claude Code** | ✅ Yes | `Co-Authored-By: Claude <noreply@anthropic.com>` | Default on; disable with `attribution.commits: false` in [Claude Code settings](https://docs.anthropic.com/en/docs/claude-code/settings) |
-| **Cursor Agent** | ❌ No | — | No automatic attribution as of June 2026 |
-| **Windsurf Agent** | ❌ No | — | No automatic attribution as of June 2026 |
+There are two ways to detect AI involvement in a PR, and you need both because they cover different Copilot features.
 
+**1. Co-authored-by trailers (any platform).**
+AI tools can add a `Co-authored-by` [trailer](https://docs.github.com/en/enterprise-cloud@latest/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) to commit messages. This is a standard Git feature. If the trailer lands on a commit, you can scan for it later. This catches IDE (VS Code) and Copilot CLI usage, and the Copilot coding agent too, since the agent tags its own commits.
+
+**2. The Copilot usage metrics API (Cloud/EMU only).**
+GitHub tracks the Copilot coding agent and Copilot code review server-side and exposes the counts through the [Copilot usage metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics). No trailers, no client configuration. The coding agent already shows up in the trailer scan, but the API gives you its exact count separately, plus review coverage and time-to-merge that trailers cannot provide.
+
+Which detection method you need depends on which Copilot features are in play. That is what the two scripts below are for.
+
+---
+
+## The Two Scripts
+
+This guide ships two example scripts. Run one or both depending on which Copilot features your developers use.
+
+| Script | What it measures | When you need it |
+|---|---|---|
+| `ai-leverage-daily.sh` | AI leverage % and AI rejection rate by scanning `Co-authored-by` trailers (Copilot CLI, VS Code, Claude Code) | **Always.** This is the only way to see IDE and CLI AI usage. |
+| `copilot-cloud-agent-metrics.sh` | Coding agent PRs, code review coverage, suggestion acceptance, time-to-merge, daily active users | **Add it if you are on Cloud/EMU** and use the Copilot coding agent or Copilot code review. |
+
+`ai-leverage-daily.sh` is the baseline. Trailers are the only signal that captures a developer using Copilot in their editor or in the CLI, and that usage is invisible to the metrics API. Start here regardless of platform.
+
+`copilot-cloud-agent-metrics.sh` adds two things. First, it isolates the Copilot coding agent subset of your PRs, which you can subtract from the trailer total to see how much leverage comes from IDE and CLI usage. Second, it reports metrics trailers cannot provide at all: code review coverage, suggestion acceptance, and velocity numbers like time-to-merge. It only works on Cloud/EMU because the usage metrics API is Cloud-only.
 
 > [!NOTE]
-> **Note the different email addresses**: Copilot CLI uses the GitHub noreply format (`223556219+Copilot@users.noreply.github.com`) while VS Code's built-in setting uses `copilot@github.com`. Both are valid, but your query patterns need to match both.
+> The scripts are example implementations meant for manual testing and as a starting point you can adapt. For ongoing measurement, run them on a daily schedule in whatever pipeline you already use. See [Running it on a schedule](#running-it-on-a-schedule).
+
+### Picking your scripts
+
+| Your setup | Scripts to run |
+|---|---|
+| GHES, or developers only use IDE/CLI | `ai-leverage-daily.sh` |
+| Cloud/EMU, want AI leverage % only | `ai-leverage-daily.sh` |
+| Cloud/EMU, using coding agent and/or Copilot code review | both |
 
 ---
 
-## Configuration: Ensuring AI Commits Are Tagged
+## Underlying APIs
 
-### VS Code Setting (IDE-Level)
+The scripts are examples. If you want to build your own tooling, here are the exact endpoints each one calls so you do not have to read the source. All links point to the GitHub REST API reference.
 
-The VS Code Git extension has a built-in [`git.addAICoAuthor`](https://github.com/microsoft/vscode/blob/main/extensions/git/package.json) setting with three values:
+### ai-leverage-daily.sh
+
+This script finds recently closed PRs, then checks each one's commits for an AI co-author trailer.
+
+| Step | Endpoint | Docs |
+|---|---|---|
+| Find closed PRs in the org and time window | `GET /search/issues` | [Search issues and pull requests](https://docs.github.com/en/enterprise-cloud@latest/rest/search/search#search-issues-and-pull-requests) |
+| Get a PR's merge status (`merged_at` vs `closed_at`) | `GET /repos/{owner}/{repo}/pulls/{pull_number}` | [Get a pull request](https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls#get-a-pull-request) |
+| List a PR's commits to scan trailers | `GET /repos/{owner}/{repo}/pulls/{pull_number}/commits` | [List commits on a pull request](https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls#list-commits-on-a-pull-request) |
+
+It needs read access to repository contents and pull requests (`repo` scope on a PAT, or Contents + Pull requests read on a GitHub App).
+
+### copilot-cloud-agent-metrics.sh
+
+This script pulls pre-aggregated PR metrics from the Copilot usage metrics reports. Each endpoint returns `download_links` to an NDJSON report that the script then downloads and parses.
+
+| Report | Endpoint | Docs |
+|---|---|---|
+| Org, single day | `GET /orgs/{org}/copilot/metrics/reports/organization-1-day?day=YYYY-MM-DD` | [Copilot usage metrics](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics) |
+| Org, 28-day rolling | `GET /orgs/{org}/copilot/metrics/reports/organization-28-day/latest` | [Copilot usage metrics](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics) |
+| Enterprise, single day | `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-1-day?day=YYYY-MM-DD` | [Copilot usage metrics](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics) |
+| Enterprise, 28-day rolling | `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-28-day/latest` | [Copilot usage metrics](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics) |
+
+It needs the **Copilot usage metrics** policy enabled, plus org admin, billing manager, or the "View Copilot Metrics" permission. A PAT needs `manage_billing:copilot` or `read:enterprise`.
+
+### GitHub App auth (used by both scripts)
+
+If you authenticate as a GitHub App for the higher rate limit, both scripts call one more endpoint to mint a token from your App's private key.
+
+| Step | Endpoint | Docs |
+|---|---|---|
+| Create an installation access token | `POST /app/installations/{installation_id}/access_tokens` | [Create an installation access token](https://docs.github.com/en/enterprise-cloud@latest/rest/apps/apps#create-an-installation-access-token-for-an-app) |
+
+See [github-app-setup.md](./ai-commit-attribution/github-app-setup.md) for the one-time App creation steps.
+
+---
+
+## Making IDE Usage Measurable
+
+Trailer scanning only finds what is tagged. Copilot CLI tags commits by default, but VS Code does not. If you want IDE Copilot usage to show up in your AI leverage number, you have to turn the trailer on and push it to your developers.
+
+### Which tools tag commits today
+
+| Tool | Adds trailer by default? | Trailer format |
+|---|---|---|
+| **Copilot CLI** | Yes | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` |
+| **VS Code agent mode** | No (opt-in) | `Co-authored-by: Copilot <copilot@github.com>` |
+| **Claude Code** | Yes | `Co-Authored-By: Claude <noreply@anthropic.com>` |
+| **Cursor agent** | No | none |
+| **Windsurf agent** | No | none |
+
+VS Code shipped the setting default-on for a few weeks in spring 2026 ([PR 310226](https://github.com/microsoft/vscode/pull/310226) flipped the default to `all`), then walked it back to `off` ([PR 313931](https://github.com/microsoft/vscode/pull/313931)) after a debate over what `Co-authored-by` should mean for an AI. It is opt-in again today. Note the two different Copilot emails: the CLI uses the GitHub noreply address, while the VS Code setting uses `copilot@github.com`. Your scan pattern has to match both. The script uses `co-authored-by:.*(copilot|claude)`, which catches all of them.
+
+### The VS Code setting
+
+VS Code's Git extension has a [`git.addAICoAuthor`](https://github.com/microsoft/vscode/blob/main/extensions/git/package.json) setting:
 
 | Value | Behavior |
 |---|---|
-| `"off"` | Never add trailer **(default)** |
-| `"chatAndAgent"` | Add trailer when code from chat or agent edits is included |
-| `"all"` | Add trailer when any AI-generated code is included (inline completions, chat, and agent edits) |
+| `"off"` | Never add the trailer (default) |
+| `"chatAndAgent"` | Add the trailer when code from chat or agent edits is included |
+| `"all"` | Add the trailer when any AI-generated code is included, including inline completions |
 
-Test locally by adding it to your VS Code user settings:
+Test it locally first:
 
 ```json
 // VS Code user settings (Cmd+Shift+P → "Preferences: Open User Settings (JSON)")
@@ -59,17 +153,11 @@ Test locally by adding it to your VS Code user settings:
 }
 ```
 
-**Key constraint: This is NOT an enforceable enterprise policy.** The VS Code [enterprise policy allowlist](https://code.visualstudio.com/docs/enterprise/policies) does not include `git.addAICoAuthor`. This means:
+Make a commit from agent mode and confirm the trailer appears.
 
-- It will **not** appear in ADMX/Group Policy templates or Intune Settings Catalog
-- It **cannot** be locked — developers can override it in their user settings
-- It will **not** show the "managed by your organization" lock icon in VS Code
+### Deploying it fleet-wide via MDM
 
-This is the same constraint as [Copilot OpenTelemetry settings](https://code.visualstudio.com/docs/agents/guides/monitoring-agents) — you can push it as an overridable default, but you cannot enforce it. The [Copilot OpenTelemetry via Intune](./copilot-otel-intune) guide covers the full Intune deployment pattern; the MDM scripts below follow that same approach for `git.addAICoAuthor`.
-
-#### Deploying via MDM (Intune example)
-
-Push `git.addAICoAuthor` as a default into each developer's VS Code `settings.json` via an MDM script.
+`git.addAICoAuthor` is a regular VS Code setting, not an enterprise policy. It is not on the VS Code [policy allowlist](https://code.visualstudio.com/docs/enterprise/policies), so it will not appear in ADMX/Group Policy or the Intune Settings Catalog, and you cannot lock it. You can still push it as a default through an MDM script, the same approach the [Copilot OpenTelemetry via Intune](./copilot-otel-intune) guide uses. Developers can override it, but most will not bother, which is fine for an adoption-measurement use case.
 
 **macOS** — Intune → Devices → Scripts → shell script, run as root:
 
@@ -117,228 +205,107 @@ if (Test-Path $settingsPath) {
 }
 ```
 
-> [!NOTE]
-> These are overridable defaults. A developer can change the setting in their VS Code preferences. For observability use cases (measuring AI adoption) this is acceptable — most developers won't bother overriding it. For compliance/audit requirements where override is unacceptable, the server-side metrics on Cloud/EMU are the only enforceable path.
-
 > [!IMPORTANT]
-> **Known gap:** Cursor and Windsurf do not add AI attribution trailers and do not expose environment signals that would allow external detection. Commits from those tools will not show up in AI leverage queries unless the developer manually adds a trailer.
+> Cursor and Windsurf do not add AI attribution trailers and do not expose a signal you can detect externally. Commits from those tools will not show up in your AI leverage number unless the developer adds a trailer by hand.
 
 ---
 
-## Measuring AI Leverage: Querying PRs on GHES
+## Running the Scripts
 
-Once trailers are landing on commits, you can measure what GitHub's [Engineering System Success Playbook](https://github.com/resources/insights/engineering-system-success-playbook) (ESSP) calls **AI leverage** — the percentage of merged PRs that contain at least one AI-authored commit.
+### ai-leverage-daily.sh
 
-See also: [Well-Architected Framework: Engineering System Metrics](https://wellarchitected.github.com/library/productivity/recommendations/engineering-system-metrics/) for a TLDR of the ESSP
-
-The goal: **What percentage of merged PRs in a given period contained at least one AI-authored commit?**
-
-### Trailer Patterns to Search For
-
-Different tools use different trailer formats. Your queries need to match all variants in use:
-
-| Tool | Trailer format |
-|---|---|
-| Copilot CLI | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` |
-| VS Code (`git.addAICoAuthor`) | `Co-authored-by: Copilot <copilot@github.com>` |
-| Claude Code | `Co-Authored-By: Claude <noreply@anthropic.com>` |
-
-A broad match pattern that catches both Copilot trailer variants: `Co-authored-by:.*Copilot` — this works because "Copilot" appears as the author name in both formats, before the email address.
-
-### Approach: Daily GHES REST API Job
-
-Run this as a daily GitHub Actions workflow or cron job. The script iterates all repos in the org, pulls closed PRs from the last 24 hours, classifies each as merged or closed-without-merge, and checks commit messages for Copilot trailers.
-
-This gives you two signals from the [ESSP](https://github.com/resources/insights/engineering-system-success-playbook):
-- **AI leverage (throughput)** — what % of merged PRs had AI involvement?
-- **AI rejection rate (quality)** — what % of AI-attributed PRs were closed without merging? A high rejection rate may indicate AI-generated code that doesn't meet quality standards.
+Scans every repo's recently closed PRs and reports the share that had an AI co-author trailer.
 
 ```bash
-#!/bin/bash
-# ai-leverage-daily.sh
-# Daily job: calculates AI leverage and AI rejection rate for an org on GHES.
-# Designed for cron / GitHub Actions. Processes the previous day's closed PRs.
-#
-# Usage: GHES_TOKEN=xxx GHES_HOSTNAME=github.example.com ./ai-leverage-daily.sh MY_ORG
-#
-# Output: JSON report to stdout (pipe to file, dashboard, or artifact)
+# Uses your gh CLI auth or GH_TOKEN
+./ai-commit-attribution/scripts/ai-leverage-daily.sh octodemo
 
-set -euo pipefail
-
-ORG="${1:?Usage: $0 <org>}"
-SINCE=$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "1 day ago" +%Y-%m-%dT%H:%M:%SZ)
-API="https://${GHES_HOSTNAME}/api/v3"
-AUTH="Authorization: token ${GHES_TOKEN}"
-ACCEPT="Accept: application/vnd.github+json"
-
-TOTAL_MERGED=0
-TOTAL_CLOSED=0
-AI_MERGED=0
-AI_CLOSED=0
-
-# Paginated GET — returns all pages concatenated as a JSON array
-paginate() {
-  local url="$1" page=1 sep="["
-  while true; do
-    local body
-    body=$(curl -s -H "$AUTH" -H "$ACCEPT" "${url}&page=${page}&per_page=100")
-    local count
-    count=$(echo "$body" | jq 'length')
-    echo "$body" | jq -c '.[]' | while read -r item; do echo "${sep}${item}"; sep=","; done
-    [[ "$count" -lt 100 ]] && break
-    ((page++))
-    sleep 0.3
-  done
-  echo "]"
-}
-
-# Check if any commit in a PR has a Copilot trailer
-pr_has_ai() {
-  local repo="$1" pr_num="$2"
-  curl -s -H "$AUTH" -H "$ACCEPT" "$API/repos/$repo/pulls/$pr_num/commits?per_page=100" | \
-    jq -r '[.[].commit.message] | join("\n")' | \
-    grep -qi "co-authored-by:.*copilot" && return 0 || return 1
-}
-
-# Get all repos in the org
-REPOS=$(curl -s -H "$AUTH" -H "$ACCEPT" "$API/orgs/$ORG/repos?type=all&per_page=100" | \
-  jq -r '.[].full_name')
-
-for REPO in $REPOS; do
-  # Fetch PRs closed/merged since yesterday
-  PRS_JSON=$(curl -s -H "$AUTH" -H "$ACCEPT" \
-    "$API/repos/$REPO/pulls?state=closed&sort=updated&direction=desc&per_page=100")
-
-  # Process each PR closed within our window
-  echo "$PRS_JSON" | jq -c --arg since "$SINCE" \
-    '.[] | select(.closed_at >= $since)' | while read -r PR; do
-
-    PR_NUM=$(echo "$PR" | jq -r '.number')
-    MERGED_AT=$(echo "$PR" | jq -r '.merged_at')
-
-    if [[ "$MERGED_AT" != "null" ]]; then
-      ((TOTAL_MERGED++)) || true
-      if pr_has_ai "$REPO" "$PR_NUM"; then
-        ((AI_MERGED++)) || true
-      fi
-    else
-      ((TOTAL_CLOSED++)) || true
-      if pr_has_ai "$REPO" "$PR_NUM"; then
-        ((AI_CLOSED++)) || true
-      fi
-    fi
-    sleep 0.2
-  done
-done
-
-# Output report as JSON
-cat <<EOF
-{
-  "date": "$(date -u +%Y-%m-%d)",
-  "org": "$ORG",
-  "total_merged_prs": $TOTAL_MERGED,
-  "ai_attributed_merged": $AI_MERGED,
-  "ai_leverage_pct": $(echo "scale=1; if ($TOTAL_MERGED > 0) $AI_MERGED * 100 / $TOTAL_MERGED else 0" | bc),
-  "total_closed_without_merge": $TOTAL_CLOSED,
-  "ai_attributed_closed": $AI_CLOSED,
-  "ai_rejection_rate_pct": $(echo "scale=1; a=$AI_MERGED+$AI_CLOSED; if (a > 0) $AI_CLOSED * 100 / a else 0" | bc)
-}
-EOF
+# Scan a specific window
+./ai-commit-attribution/scripts/ai-leverage-daily.sh octodemo --since 2026-06-18T00:00:00Z
 ```
 
-**What this measures:**
+Output (stdout is clean JSON; progress goes to stderr):
+
+```json
+{
+  "date": "2026-06-19",
+  "org": "octodemo",
+  "since": "2026-06-18T19:30:04Z",
+  "prs_checked": 116,
+  "total_merged_prs": 23,
+  "ai_attributed_merged": 8,
+  "ai_leverage_pct": 34.8,
+  "total_closed_without_merge": 46,
+  "ai_attributed_closed": 1,
+  "ai_rejection_rate_pct": 11.1
+}
+```
 
 | Metric | Formula | ESSP zone |
 |---|---|---|
-| AI leverage | AI-attributed merged PRs ÷ total merged PRs | Business Outcomes (Activity) |
+| AI leverage | AI-attributed merged PRs ÷ total merged PRs | Activity |
 | AI rejection rate | AI-attributed closed-without-merge ÷ all AI-attributed PRs | Quality |
-| PR merge rate | Total merged PRs ÷ total developers | Velocity |
 
-A rising rejection rate for AI-attributed PRs (compared to non-AI PRs) could indicate that AI-generated code isn't passing review — worth investigating with the team before drawing conclusions.
+A rising rejection rate for AI PRs, compared to non-AI PRs, can mean AI-generated code is not passing review. Treat it as a prompt to talk to the team, not a conclusion.
+
+### copilot-cloud-agent-metrics.sh
+
+Pulls Copilot coding agent and code review metrics from the usage metrics API.
+
+```bash
+# Yesterday (default)
+./ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh octodemo
+
+# A specific day, the last N days, or the 28-day rolling report
+./ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh octodemo --day 2026-06-18
+./ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh octodemo --days 7
+./ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh octodemo --28day
+
+# Enterprise level
+./ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh octodemo --enterprise my-enterprise --28day
+```
+
+The coding agent adds a `Co-authored-by: Copilot` trailer too, so its PRs already count toward the trailer scan's total. What this script adds is the breakdown. The coding-agent-only count (`total_merged_created_by_copilot`) lets you subtract that subset from the trailer total to see how much of your AI leverage comes from IDE, CLI, and Claude instead. It also reports things trailers cannot show at all: code review coverage (`total_reviewed_by_copilot`), suggestion acceptance, median time-to-merge, and daily active users. See the [scripts README](./ai-commit-attribution/README.md) for the full output schema and ESSP mapping.
+
+### Running it on a schedule
+
+The scripts are for manual testing and as a starting point. For ongoing measurement, run `ai-leverage-daily.sh` (and `copilot-cloud-agent-metrics.sh` if you need it) once a day in whatever pipeline you already operate. A scheduled GitHub Actions workflow, a Jenkins job, a GitLab CI schedule, or a plain cron entry all work. Pipe the JSON output to a dashboard, a database, or a build artifact.
+
+For anything beyond a small org, authenticate as a GitHub App rather than a PAT. App installation tokens get 15,000 requests/hour versus 5,000 for a PAT, and they expire after an hour. See [github-app-setup.md](./ai-commit-attribution/github-app-setup.md).
 
 > [!NOTE]
-> **Rate limits:** GHES has rate limits [disabled by default](https://docs.github.com/en/enterprise-server@3.21/admin/configuring-settings/configuring-rate-limits/configuring-rate-limits-for-your-instance). If your instance has them enabled, or you're adapting this for GHEC (15,000 requests/hour), a daily cadence keeps volumes manageable — a 1,000-repo org with ~50 PRs closed per day uses roughly 1,000 + 50 = ~1,050 API calls per run.
+> The trailer scan finds closed PRs through the Search API instead of walking every repo, so its cost scales with the number of closed PRs, not the number of repos. Each closed PR costs about two calls (one for merge status, one for its commits), so a day with 50 closed PRs is roughly 100 calls. The metrics API script uses one or two calls per run.
 
 ---
 
-## Limitations & Gaps
+## Two Signals, One Picture
 
-- **IDE completions are NOT tracked** — This approach only covers agent/CLI sessions where AI makes commits. A developer using Copilot inline suggestions in the editor gets no trailer. The `"all"` value for `git.addAICoAuthor` attempts to cover completions, but detection accuracy for inline completions is lower than for agent/chat edits.
-- **`git.addAICoAuthor` is not enforceable** — It's a regular VS Code setting, not an [enterprise policy](https://code.visualstudio.com/docs/enterprise/policies). Developers can override it.
-- **Trailers are removable** — Developers can edit commit messages before pushing. This is an honesty system.
-- **False positives are possible** — VS Code's `git.addAICoAuthor` [historically tagged commits even when AI wasn't actually used](https://github.com/microsoft/vscode/pull/310226) (part of why it was reverted from default-on)
-- **No standard trailer yet** — Industry is split between `Co-authored-by`, `Assisted-by`, and `AI-Generated-By`. The Linux kernel is exploring `Assisted-by`. Microsoft is tracking this in [vscode#313962](https://github.com/microsoft/vscode/issues/313962).
-- **Cross-tool inconsistency** — Different tools use different trailer formats and email addresses, requiring broad grep patterns
+On Cloud/EMU the two scripts answer different questions, and the gap between them is the point.
 
----
-
-## Measuring the Full Picture: Two Scripts, Two Signals
-
-AI leverage from `ai-leverage-daily.sh` (trailer scanning) captures **all** AI-attributed PRs — including those from the Copilot coding agent, which adds `Co-authored-by: Copilot` trailers to its commits. This gives you the core AI leverage metric on any platform.
-
-`copilot-cloud-agent-metrics.sh` adds **metrics you can't get from trailers**: time-to-merge comparisons, code review coverage, suggestion acceptance rates, and daily active user counts. It queries the [Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics), which is only available on Cloud/EMU.
-
-| Script | What it gives you | Platform |
-|---|---|---|
-| `ai-leverage-daily.sh` | AI leverage %, AI rejection rate, multi-tool coverage (Copilot + Claude) | Any (GHES or Cloud) |
-| `copilot-cloud-agent-metrics.sh` | Time-to-merge, code review stats, suggestion acceptance, daily active users | Cloud/EMU only |
-
-### When you need which
-
-| Scenario | Scripts needed |
-|---|---|
-| GHES customer | `ai-leverage-daily.sh` only |
-| Cloud/EMU, want AI leverage % only | `ai-leverage-daily.sh` only |
-| Cloud/EMU, want full ESSP metrics (velocity, quality, throughput) | **Both scripts** |
-
-### Real-world example: octodemo (June 18, 2026)
-
-Running both scripts against the same org on the same day:
+Trailer scanning counts **any** PR with an AI co-author, so it is the superset for AI leverage: coding agent PRs (which add trailers), plus IDE and CLI usage, plus Claude Code. The usage metrics API counts a narrower thing, `total_merged_created_by_copilot`, which is only PRs the coding agent fully created. Running both on octodemo for the same day:
 
 | Metric | `ai-leverage-daily.sh` | `copilot-cloud-agent-metrics.sh` |
 |---|---|---|
 | Total merged PRs | 23 | 23 |
-| AI-attributed merged | **8 (34.8%)** | **2 (8.7%)** |
+| AI-attributed merged | 8 (34.8%) | 2 (8.7%) |
 | AI rejection rate | 11.1% | — |
 | PRs reviewed by Copilot | — | 345 |
 | Median time to merge | — | 0.53 min |
 | Median TTM (Copilot-authored) | — | 10.25 min |
 | Daily active Copilot users | — | 812 |
 
-The trailer script found 8 AI PRs (including coding agent PRs). The Metrics API found only 2 `total_merged_created_by_copilot` — a narrower count that only includes PRs the coding agent fully created. The trailer script's higher number reflects IDE/CLI AI usage plus coding agent, giving the broader AI leverage picture.
+The trailer scan found 8 AI PRs; the metrics API found 2. Both are right, and the gap is the useful part. The coding agent tags its commits, so its 2 PRs are already inside the trailer scan's 8. Subtract the agent count and you learn that 6 of the 8 came from developers using Copilot in their editor or the CLI. That split is exactly why you run the trailer scan everywhere and add the metrics API when you have coding agent or review activity to break out.
 
-### What the Copilot Metrics API adds beyond trailers
-
-| Capability | `ai-leverage-daily.sh` | `copilot-cloud-agent-metrics.sh` |
-|---|---|---|
-| AI leverage (all tools) | ✅ | — (narrower: coding agent only) |
-| Coding agent PRs | ✅ (via trailer) | ✅ `total_merged_created_by_copilot` |
-| Time-to-merge comparison | ❌ | ✅ `median_minutes_to_merge_copilot_authored` |
-| Copilot code review | ❌ | ✅ `total_merged_reviewed_by_copilot` |
-| Review suggestion acceptance | ❌ | ✅ `total_copilot_applied_suggestions` |
-| Multi-tool coverage (Claude, etc.) | ✅ | ❌ Copilot only |
-| AI rejection rate | ✅ | ❌ |
-| Daily active users | ❌ | ✅ |
-| Works on GHES | ✅ | ❌ Cloud/EMU only |
-
-See [ai-commit-attribution/ghes-vs-cloud-comparison.md](./ai-commit-attribution/ghes-vs-cloud-comparison.md) for the detailed analysis.
-
-### Scripts
-
-Both scripts are in the [ai-commit-attribution/scripts/](./ai-commit-attribution/scripts/) directory:
-
-- **[`ai-leverage-daily.sh`](./ai-commit-attribution/scripts/ai-leverage-daily.sh)** — trailer scanning for IDE/CLI AI usage (any platform)
-- **[`copilot-cloud-agent-metrics.sh`](./ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh)** — Copilot coding agent + code review metrics (Cloud/EMU only)
-- **[`generate-installation-token.sh`](./ai-commit-attribution/scripts/generate-installation-token.sh)** — GitHub App token generation
-
-See [ai-commit-attribution/github-app-setup.md](./ai-commit-attribution/github-app-setup.md) for GitHub App setup instructions (recommended for large orgs due to the 15,000 req/hr rate limit vs 5,000 for PATs).
+See [ghes-vs-cloud-comparison.md](./ai-commit-attribution/ghes-vs-cloud-comparison.md) for the full side-by-side with real data.
 
 ---
 
-## Recommended Implementation Order
+## Limitations
 
-1. **Test locally** — set `"git.addAICoAuthor": "all"` in your own VS Code settings and verify trailers appear on commits from agent mode
-2. Copilot CLI already tags by default — no action needed
-3. **Deploy fleet-wide via MDM** — push the setting as a managed default through Intune (see [MDM section above](#deploying-via-mdm-intune-example))
-4. **Set up the daily job** — schedule `ai-leverage-daily.sh` as a GitHub Actions workflow or cron
-5. **If using Copilot coding agent or PR review on Cloud** — add `copilot-cloud-agent-metrics.sh` to your daily job to capture platform-level metrics
+- **Inline completions need the `all` setting.** `git.addAICoAuthor` only tags inline completions at the `all` level. The `chatAndAgent` value tags chat and agent edits but skips completions by design, so a fleet on `chatAndAgent` undercounts editor usage.
+- **`git.addAICoAuthor` is not enforceable.** It is a regular VS Code setting, not an [enterprise policy](https://code.visualstudio.com/docs/enterprise/policies). Developers can turn it off.
+- **Trailers are removable.** A developer can edit a commit message before pushing. This is an honesty system, not an audit trail.
+- **No standard trailer yet.** The industry is split between `Co-authored-by`, `Assisted-by`, and `AI-Generated-By`. The Linux kernel is looking at `Assisted-by`; Microsoft is tracking it in [vscode#313962](https://github.com/microsoft/vscode/issues/313962).
+- **Cursor and Windsurf are invisible.** Neither tags commits nor exposes a detectable signal.
+
+None of this makes the number useless. It makes it a directional adoption metric rather than a compliance audit. If you need an enforceable, server-side count, that is what the Copilot usage metrics API gives you on Cloud/EMU, within its narrower coding-agent definition.

--- a/ai-commit-attribution.md
+++ b/ai-commit-attribution.md
@@ -1,0 +1,287 @@
+---
+layout: default
+title: AI Commit Attribution — GHES Runbook
+toc: true
+---
+
+# AI Commit Attribution — GHES Runbook
+{:.no_toc}
+
+*Last updated: June 19, 2026*
+
+How to track which Pull Requests contain AI-authored commits on GitHub Enterprise Server, where Cloud/EMU-only PR metrics are unavailable.
+
+---
+
+## Why This Matters
+
+GitHub Enterprise Cloud exposes native API metrics for AI-attributed PRs — fields like `total_merged_created_by_copilot` in the [Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics). GHES customers don't have access to these metrics.
+
+However, the underlying mechanism is portable: AI tools add a `Co-authored-by` [trailer](https://docs.github.com/en/enterprise-cloud@latest/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) to git commit messages. This is a standard Git feature that works on any platform. If you make sure these trailers land on commits and then query for them, you get equivalent visibility on GHES.
+
+---
+
+## Tool Landscape: What Tags Commits Today?
+
+| Tool | Adds trailer by default? | Trailer format | Source |
+|---|---|---|---|
+| **Copilot CLI** | ✅ Yes | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` | Built into CLI system prompt |
+| **VS Code Agent Mode** | ❌ No (opt-in) | `Co-authored-by: Copilot <copilot@github.com>` | Was default in [v1.118](https://code.visualstudio.com/updates/v1_118) (April 2026), [reverted in v1.119](https://github.com/microsoft/vscode/pull/310226) after community backlash (372 👎). Opt-in via `git.addAICoAuthor` setting. |
+| **Claude Code** | ✅ Yes | `Co-Authored-By: Claude <noreply@anthropic.com>` | Default on; disable with `attribution.commits: false` in [Claude Code settings](https://docs.anthropic.com/en/docs/claude-code/settings) |
+| **Cursor Agent** | ❌ No | — | No automatic attribution as of June 2026 |
+| **Windsurf Agent** | ❌ No | — | No automatic attribution as of June 2026 |
+
+Bottom line: Copilot CLI and Claude Code handle this automatically. VS Code agent mode — the most common agent workflow — requires you to turn it on.
+
+> [!NOTE]
+> **Note the different email addresses**: Copilot CLI uses the GitHub noreply format (`223556219+Copilot@users.noreply.github.com`) while VS Code's built-in setting uses `copilot@github.com`. Both are valid, but your query patterns need to match both.
+
+---
+
+## Configuration: Ensuring AI Commits Are Tagged
+
+Two approaches. Recommend both for defense in depth.
+
+### Option A: VS Code Setting (IDE-Level) — Recommended Starting Point
+
+The VS Code Git extension has a built-in [`git.addAICoAuthor`](https://github.com/microsoft/vscode/blob/main/extensions/git/package.json) setting with three values:
+
+| Value | Behavior |
+|---|---|
+| `"off"` | Never add trailer **(default)** |
+| `"chatAndAgent"` | Add trailer when code from chat or agent edits is included |
+| `"all"` | Add trailer when any AI-generated code is included (inline completions, chat, and agent edits) |
+
+Enable it in workspace settings committed to repos:
+
+```json
+// .vscode/settings.json (committed to repo)
+{
+  "git.addAICoAuthor": "all"
+}
+```
+
+**Key constraint: This is NOT an enforceable enterprise policy.** The VS Code [enterprise policy allowlist](https://code.visualstudio.com/docs/enterprise/policies) does not include `git.addAICoAuthor`. This means:
+
+- It will **not** appear in ADMX/Group Policy templates or Intune Settings Catalog
+- It **cannot** be locked — developers can override it in their user settings
+- It will **not** show the "managed by your organization" lock icon in VS Code
+
+This is the same constraint as [Copilot OpenTelemetry settings](https://code.visualstudio.com/docs/agents/guides/monitoring-agents) — you can push it as an overridable default, but you cannot enforce it. See the [Copilot OpenTelemetry via Intune](./copilot-otel-intune) guide for the full pattern.
+
+#### Deploying via MDM (Intune example)
+
+Push `git.addAICoAuthor` as a default into each developer's VS Code `settings.json` via an MDM script. Same mechanism as OTel deployment (see [Copilot OpenTelemetry via Intune — Part 2A](./copilot-otel-intune#2a-vs-code-half--default-settingsjson-shell-script) for the full pattern).
+
+**macOS** — Intune → Devices → Scripts → shell script, run as root:
+
+```bash
+#!/bin/bash
+# deploy-vscode-ai-coauthor.sh
+# Merges git.addAICoAuthor into each user's VS Code settings.
+# This is a DEFAULT — users can still override it.
+
+for HOME_DIR in /Users/*; do
+  USER_NAME=$(basename "$HOME_DIR")
+  [ "$USER_NAME" = "Shared" ] && continue
+  SETTINGS_DIR="$HOME_DIR/Library/Application Support/Code/User"
+  SETTINGS="$SETTINGS_DIR/settings.json"
+  [ -d "$HOME_DIR/Library/Application Support/Code" ] || continue
+  mkdir -p "$SETTINGS_DIR"
+
+  if command -v jq >/dev/null 2>&1 && [ -f "$SETTINGS" ]; then
+    tmp=$(mktemp)
+    jq '."git.addAICoAuthor" = "all"' "$SETTINGS" > "$tmp" && mv "$tmp" "$SETTINGS"
+  else
+    cat > "$SETTINGS" <<'EOF'
+{
+  "git.addAICoAuthor": "all"
+}
+EOF
+  fi
+  chown "$USER_NAME" "$SETTINGS"
+done
+```
+
+**Windows** — Intune → Devices → Scripts and remediations → Platform scripts, run in user context:
+
+```powershell
+# Set-AICoAuthor.ps1
+$settingsPath = "$env:APPDATA\Code\User\settings.json"
+if (Test-Path $settingsPath) {
+    $json = Get-Content $settingsPath -Raw | ConvertFrom-Json
+    $json | Add-Member -NotePropertyName 'git.addAICoAuthor' -NotePropertyValue 'all' -Force
+    $json | ConvertTo-Json -Depth 10 | Set-Content $settingsPath
+} else {
+    $dir = Split-Path $settingsPath
+    if (!(Test-Path $dir)) { New-Item -ItemType Directory -Path $dir -Force }
+    '{ "git.addAICoAuthor": "all" }' | Set-Content $settingsPath
+}
+```
+
+> [!NOTE]
+> These are overridable defaults. A developer can change the setting in their VS Code preferences. For observability use cases (measuring AI adoption) this is acceptable — most developers won't bother overriding it. For compliance/audit requirements where override is unacceptable, the server-side metrics on Cloud/EMU are the only enforceable path.
+
+### Option B: Git Hook (Repo-Level, Tool-Agnostic)
+
+A [`prepare-commit-msg`](https://git-scm.com/docs/githooks#_prepare_commit_msg) hook catches commits from ALL agent tools — including Cursor, Windsurf, or any future tool that runs `git commit`:
+
+```bash
+#!/bin/bash
+# .git/hooks/prepare-commit-msg
+# Adds AI co-author trailer when an AI agent session is detected
+
+COMMIT_MSG_FILE="$1"
+COMMIT_SOURCE="$2"
+
+# Skip merge/squash commits
+[[ "$COMMIT_SOURCE" == "merge" || "$COMMIT_SOURCE" == "squash" ]] && exit 0
+
+# Check if trailer already exists (from VS Code setting or tool default)
+grep -qi "Co-authored-by:.*\(Copilot\|Claude\|AI-Agent\)" "$COMMIT_MSG_FILE" && exit 0
+
+# Detect AI agent sessions via environment signals
+AI_DETECTED=false
+[[ -n "$COPILOT_SESSION" ]] && AI_DETECTED=true  # Copilot CLI
+[[ -n "$CLAUDE_CODE" ]] && AI_DETECTED=true       # Claude Code
+
+# Alternative: "always-on" approach — tag all commits unconditionally
+# Uncomment the line below if you want to assume AI is always involved:
+# AI_DETECTED=true
+
+if [[ "$AI_DETECTED" == "true" ]]; then
+    TRAILER="Co-authored-by: AI-Agent <ai-agent@company.com>"
+    git interpret-trailers --in-place --trailer "$TRAILER" "$COMMIT_MSG_FILE"
+fi
+```
+
+**Distribution options:**
+- Set org-wide default hooks directory: `git config --global core.hooksPath ~/.git-hooks` ([git docs](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath))
+- Use hook managers: [Husky](https://typicode.github.io/husky/) (JS), [Lefthook](https://github.com/evilmartians/lefthook) (polyglot), [pre-commit](https://pre-commit.com/) (Python)
+- Bake into developer environment setup scripts or machine images
+
+**Pros**: Works with any AI tool, tool-agnostic, catches tools that don't self-tag
+**Cons**: Developers can bypass hooks with `git commit --no-verify`; requires a distribution strategy
+
+---
+
+## Measuring AI Leverage: Querying PRs on GHES
+
+This section lines up with the [Engineering System Success Playbook (ESSP)](https://github.com/resources/insights/engineering-system-success-playbook) — specifically the **(Percentage) AI leverage** metric in the Business Outcomes zone. See also the [Well-Architected Framework: Engineering System Metrics](https://wellarchitected.github.com/library/productivity/recommendations/engineering-system-metrics/).
+
+The goal: **What percentage of merged (or closed) PRs in a given period contained at least one AI-authored commit?**
+
+### Trailer Patterns to Search For
+
+Different tools use different trailer formats. Your queries need to match all variants in use:
+
+| Tool | Trailer format |
+|---|---|
+| Copilot CLI | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` |
+| VS Code (`git.addAICoAuthor`) | `Co-authored-by: Copilot <copilot@github.com>` |
+| Claude Code | `Co-Authored-By: Claude <noreply@anthropic.com>` |
+| Custom hook (if deployed) | `Co-authored-by: AI-Agent <ai-agent@company.com>` |
+
+A broad match pattern that catches all of these: `Co-authored-by:.*Copilot` and `Co-authored-by:.*Claude`
+
+### Approach: GHES REST API
+
+A GHES admin runs this centrally against the GHES API. No repo cloning or local git access required.
+
+**Step 1: List merged PRs for a repo in a date range**
+
+Use the [List pull requests](https://docs.github.com/en/enterprise-server@3.21/rest/pulls/pulls#list-pull-requests) endpoint. Filter to `state=closed`, then check `merged_at` in the response to confirm it was merged (not just closed):
+
+```bash
+curl -s -H "Authorization: token $GHES_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://GHES_HOSTNAME/api/v3/repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
+```
+
+Each result includes `merged_at` (non-null if merged) and `number` (the PR number).
+
+**Step 2: For each merged PR, fetch its commits**
+
+Use the [List commits on a pull request](https://docs.github.com/en/enterprise-server@3.21/rest/pulls/pulls#list-commits-on-a-pull-request) endpoint:
+
+```bash
+curl -s -H "Authorization: token $GHES_TOKEN" \
+  -H "Accept: application/vnd.github+json" \
+  "https://GHES_HOSTNAME/api/v3/repos/{owner}/{repo}/pulls/{pull_number}/commits?per_page=100"
+```
+
+Each commit object includes `commit.message` — check this field for AI co-author trailers.
+
+**Step 3: Check commit messages for AI trailers**
+
+For each commit in the PR, check if `commit.message` contains any of the trailer patterns above. If at least one commit has a match, the PR is "AI-attributed."
+
+**Step 4: Aggregate**
+
+```
+AI Leverage (%) = (PRs with ≥1 AI commit / Total merged PRs) × 100
+```
+
+### Scaling Across the Instance
+
+To run this across all repos in an org (or the entire GHES instance):
+
+- **List all repos**: [`GET /orgs/{org}/repos`](https://docs.github.com/en/enterprise-server@3.21/rest/repos/repos#list-organization-repositories) or [`GET /organizations`](https://docs.github.com/en/enterprise-server@3.21/rest/orgs/orgs#list-organizations) + repos per org
+- **Pagination**: All endpoints return max 100 results per page. Use `Link` header pagination to iterate.
+- **Rate limiting**: GHES rate limits are [disabled by default](https://docs.github.com/en/enterprise-server@3.21/rest/search/search) but may be enabled. Check with your GHES site admin.
+- **Commit search shortcut**: The [search commits](https://docs.github.com/en/enterprise-server@3.21/rest/search/search#search-commits) endpoint can find AI-attributed commits across repos in a single query:
+
+```bash
+curl -s -H "Authorization: token $GHES_TOKEN" \
+  -H "Accept: application/vnd.github.cloak-preview+json" \
+  "https://GHES_HOSTNAME/api/v3/search/commits?q=org:MY_ORG+author-date:>2026-05-01+Co-authored-by+Copilot"
+```
+
+> [!NOTE]
+> Search returns max 1,000 results. For large orgs, use the per-repo PR + commits approach above.
+
+### Recommended Automation
+
+Run this as a scheduled GitHub Actions workflow on GHES (or a cron job) that:
+- Queries all repos in the org for merged PRs in the last 7/30 days
+- Checks each PR's commits for AI trailers
+- Outputs a report: total PRs, AI-attributed PRs, AI leverage %, broken down by repo and by developer
+- Stores results over time to track trending
+
+---
+
+## Limitations & Gaps
+
+- **IDE completions are NOT tracked** — This approach only covers agent/CLI sessions where AI makes commits. A developer using Copilot inline suggestions in the editor gets no trailer. The `"all"` value for `git.addAICoAuthor` attempts to cover completions, but detection accuracy for inline completions is lower than for agent/chat edits.
+- **`git.addAICoAuthor` is not enforceable** — It's a regular VS Code setting, not an [enterprise policy](https://code.visualstudio.com/docs/enterprise/policies). Developers can override it. Same constraint as OTel monitoring.
+- **Trailers are removable** — Developers can edit commit messages or use `--no-verify` to skip hooks. This is an honesty system.
+- **False positives are possible** — VS Code's `git.addAICoAuthor` [historically tagged commits even when AI wasn't actually used](https://github.com/microsoft/vscode/pull/310226) (part of why it was reverted from default-on)
+- **No standard trailer yet** — Industry is split between `Co-authored-by`, `Assisted-by`, and `AI-Generated-By`. The Linux kernel is exploring `Assisted-by`. Microsoft is tracking this in [vscode#313962](https://github.com/microsoft/vscode/issues/313962).
+- **Cross-tool inconsistency** — Different tools use different trailer formats and email addresses, requiring broad grep patterns
+
+---
+
+## What Cloud/EMU Gives You Instead
+
+For comparison, GitHub Enterprise Cloud provides native metrics via the [Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics):
+
+| Capability | GHES (this runbook) | Cloud/EMU (native) |
+|---|---|---|
+| AI PR metrics | Manual query via trailers | [`total_merged_created_by_copilot`](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics) |
+| Time-to-merge comparison | DIY calculation | `median_minutes_to_merge_copilot_authored` |
+| Copilot code review tracking | Not available | `total_merged_reviewed_by_copilot` |
+| Per-user AI engagement | Not available | [Per-user metrics endpoints](https://docs.github.com/en/enterprise-cloud@latest/copilot/reference/copilot-usage-metrics/copilot-usage-metrics) |
+| Configuration required | VS Code settings + hooks (overridable) | None — works out of the box |
+| Accuracy | Depends on trailer presence (honesty system) | Server-side tracking (100% for coding agent) |
+
+The native Cloud/EMU metrics track at the platform level. No client configuration, no trailers to manage, no opt-out risk.
+
+---
+
+## Recommended Implementation Order
+
+1. Commit `.vscode/settings.json` with `"git.addAICoAuthor": "all"` to repositories (immediate, covers the most common agent workflow)
+2. Copilot CLI already tags by default — no action needed
+3. For orgs using Claude Code — already tags by default
+4. For orgs using Cursor/Windsurf or wanting a safety net — deploy a `prepare-commit-msg` hook via `core.hooksPath` or a hook manager
+5. Build a periodic query (weekly/monthly) against GHES commit search to track AI PR percentage over time

--- a/ai-commit-attribution.md
+++ b/ai-commit-attribution.md
@@ -31,7 +31,6 @@ However, the underlying mechanism is portable: AI tools add a `Co-authored-by` [
 | **Cursor Agent** | ❌ No | — | No automatic attribution as of June 2026 |
 | **Windsurf Agent** | ❌ No | — | No automatic attribution as of June 2026 |
 
-Bottom line: Copilot CLI and Claude Code handle this automatically. VS Code agent mode — the most common agent workflow — requires you to turn it on.
 
 > [!NOTE]
 > **Note the different email addresses**: Copilot CLI uses the GitHub noreply format (`223556219+Copilot@users.noreply.github.com`) while VS Code's built-in setting uses `copilot@github.com`. Both are valid, but your query patterns need to match both.
@@ -40,9 +39,7 @@ Bottom line: Copilot CLI and Claude Code handle this automatically. VS Code agen
 
 ## Configuration: Ensuring AI Commits Are Tagged
 
-Two approaches. Recommend both for defense in depth.
-
-### Option A: VS Code Setting (IDE-Level) — Recommended Starting Point
+### VS Code Setting (IDE-Level)
 
 The VS Code Git extension has a built-in [`git.addAICoAuthor`](https://github.com/microsoft/vscode/blob/main/extensions/git/package.json) setting with three values:
 
@@ -52,10 +49,10 @@ The VS Code Git extension has a built-in [`git.addAICoAuthor`](https://github.co
 | `"chatAndAgent"` | Add trailer when code from chat or agent edits is included |
 | `"all"` | Add trailer when any AI-generated code is included (inline completions, chat, and agent edits) |
 
-Enable it in workspace settings committed to repos:
+Test locally by adding it to your VS Code user settings:
 
 ```json
-// .vscode/settings.json (committed to repo)
+// VS Code user settings (Cmd+Shift+P → "Preferences: Open User Settings (JSON)")
 {
   "git.addAICoAuthor": "all"
 }
@@ -67,11 +64,11 @@ Enable it in workspace settings committed to repos:
 - It **cannot** be locked — developers can override it in their user settings
 - It will **not** show the "managed by your organization" lock icon in VS Code
 
-This is the same constraint as [Copilot OpenTelemetry settings](https://code.visualstudio.com/docs/agents/guides/monitoring-agents) — you can push it as an overridable default, but you cannot enforce it. See the [Copilot OpenTelemetry via Intune](./copilot-otel-intune) guide for the full pattern.
+This is the same constraint as [Copilot OpenTelemetry settings](https://code.visualstudio.com/docs/agents/guides/monitoring-agents) — you can push it as an overridable default, but you cannot enforce it. The [Copilot OpenTelemetry via Intune](./copilot-otel-intune) guide covers the full Intune deployment pattern; the MDM scripts below follow that same approach for `git.addAICoAuthor`.
 
 #### Deploying via MDM (Intune example)
 
-Push `git.addAICoAuthor` as a default into each developer's VS Code `settings.json` via an MDM script. Same mechanism as OTel deployment (see [Copilot OpenTelemetry via Intune — Part 2A](./copilot-otel-intune#2a-vs-code-half--default-settingsjson-shell-script) for the full pattern).
+Push `git.addAICoAuthor` as a default into each developer's VS Code `settings.json` via an MDM script.
 
 **macOS** — Intune → Devices → Scripts → shell script, run as root:
 
@@ -122,54 +119,18 @@ if (Test-Path $settingsPath) {
 > [!NOTE]
 > These are overridable defaults. A developer can change the setting in their VS Code preferences. For observability use cases (measuring AI adoption) this is acceptable — most developers won't bother overriding it. For compliance/audit requirements where override is unacceptable, the server-side metrics on Cloud/EMU are the only enforceable path.
 
-### Option B: Git Hook (Repo-Level, Tool-Agnostic)
-
-A [`prepare-commit-msg`](https://git-scm.com/docs/githooks#_prepare_commit_msg) hook catches commits from ALL agent tools — including Cursor, Windsurf, or any future tool that runs `git commit`:
-
-```bash
-#!/bin/bash
-# .git/hooks/prepare-commit-msg
-# Adds AI co-author trailer when an AI agent session is detected
-
-COMMIT_MSG_FILE="$1"
-COMMIT_SOURCE="$2"
-
-# Skip merge/squash commits
-[[ "$COMMIT_SOURCE" == "merge" || "$COMMIT_SOURCE" == "squash" ]] && exit 0
-
-# Check if trailer already exists (from VS Code setting or tool default)
-grep -qi "Co-authored-by:.*\(Copilot\|Claude\|AI-Agent\)" "$COMMIT_MSG_FILE" && exit 0
-
-# Detect AI agent sessions via environment signals
-AI_DETECTED=false
-[[ -n "$COPILOT_SESSION" ]] && AI_DETECTED=true  # Copilot CLI
-[[ -n "$CLAUDE_CODE" ]] && AI_DETECTED=true       # Claude Code
-
-# Alternative: "always-on" approach — tag all commits unconditionally
-# Uncomment the line below if you want to assume AI is always involved:
-# AI_DETECTED=true
-
-if [[ "$AI_DETECTED" == "true" ]]; then
-    TRAILER="Co-authored-by: AI-Agent <ai-agent@company.com>"
-    git interpret-trailers --in-place --trailer "$TRAILER" "$COMMIT_MSG_FILE"
-fi
-```
-
-**Distribution options:**
-- Set org-wide default hooks directory: `git config --global core.hooksPath ~/.git-hooks` ([git docs](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corehooksPath))
-- Use hook managers: [Husky](https://typicode.github.io/husky/) (JS), [Lefthook](https://github.com/evilmartians/lefthook) (polyglot), [pre-commit](https://pre-commit.com/) (Python)
-- Bake into developer environment setup scripts or machine images
-
-**Pros**: Works with any AI tool, tool-agnostic, catches tools that don't self-tag
-**Cons**: Developers can bypass hooks with `git commit --no-verify`; requires a distribution strategy
+> [!IMPORTANT]
+> **Known gap:** Cursor and Windsurf do not add AI attribution trailers and do not expose environment signals that would allow external detection. Commits from those tools will not show up in AI leverage queries unless the developer manually adds a trailer.
 
 ---
 
 ## Measuring AI Leverage: Querying PRs on GHES
 
-This section lines up with the [Engineering System Success Playbook (ESSP)](https://github.com/resources/insights/engineering-system-success-playbook) — specifically the **(Percentage) AI leverage** metric in the Business Outcomes zone. See also the [Well-Architected Framework: Engineering System Metrics](https://wellarchitected.github.com/library/productivity/recommendations/engineering-system-metrics/).
+Once trailers are landing on commits, you can measure what GitHub's [Engineering System Success Playbook](https://github.com/resources/insights/engineering-system-success-playbook) (ESSP) calls **AI leverage** — the percentage of merged PRs that contain at least one AI-authored commit.
 
-The goal: **What percentage of merged (or closed) PRs in a given period contained at least one AI-authored commit?**
+See also: [Well-Architected Framework: Engineering System Metrics](https://wellarchitected.github.com/library/productivity/recommendations/engineering-system-metrics/) for a TLDR of the ESSP
+
+The goal: **What percentage of merged PRs in a given period contained at least one AI-authored commit?**
 
 ### Trailer Patterns to Search For
 
@@ -180,81 +141,130 @@ Different tools use different trailer formats. Your queries need to match all va
 | Copilot CLI | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` |
 | VS Code (`git.addAICoAuthor`) | `Co-authored-by: Copilot <copilot@github.com>` |
 | Claude Code | `Co-Authored-By: Claude <noreply@anthropic.com>` |
-| Custom hook (if deployed) | `Co-authored-by: AI-Agent <ai-agent@company.com>` |
 
-A broad match pattern that catches all of these: `Co-authored-by:.*Copilot` and `Co-authored-by:.*Claude`
+A broad match pattern that catches both Copilot trailer variants: `Co-authored-by:.*Copilot` — this works because "Copilot" appears as the author name in both formats, before the email address.
 
-### Approach: GHES REST API
+### Approach: Daily GHES REST API Job
 
-A GHES admin runs this centrally against the GHES API. No repo cloning or local git access required.
+Run this as a daily GitHub Actions workflow or cron job. The script iterates all repos in the org, pulls closed PRs from the last 24 hours, classifies each as merged or closed-without-merge, and checks commit messages for Copilot trailers.
 
-**Step 1: List merged PRs for a repo in a date range**
-
-Use the [List pull requests](https://docs.github.com/en/enterprise-server@3.21/rest/pulls/pulls#list-pull-requests) endpoint. Filter to `state=closed`, then check `merged_at` in the response to confirm it was merged (not just closed):
-
-```bash
-curl -s -H "Authorization: token $GHES_TOKEN" \
-  -H "Accept: application/vnd.github+json" \
-  "https://GHES_HOSTNAME/api/v3/repos/{owner}/{repo}/pulls?state=closed&sort=updated&direction=desc&per_page=100"
-```
-
-Each result includes `merged_at` (non-null if merged) and `number` (the PR number).
-
-**Step 2: For each merged PR, fetch its commits**
-
-Use the [List commits on a pull request](https://docs.github.com/en/enterprise-server@3.21/rest/pulls/pulls#list-commits-on-a-pull-request) endpoint:
+This gives you two signals from the [ESSP](https://github.com/resources/insights/engineering-system-success-playbook):
+- **AI leverage (throughput)** — what % of merged PRs had AI involvement?
+- **AI rejection rate (quality)** — what % of AI-attributed PRs were closed without merging? A high rejection rate may indicate AI-generated code that doesn't meet quality standards.
 
 ```bash
-curl -s -H "Authorization: token $GHES_TOKEN" \
-  -H "Accept: application/vnd.github+json" \
-  "https://GHES_HOSTNAME/api/v3/repos/{owner}/{repo}/pulls/{pull_number}/commits?per_page=100"
+#!/bin/bash
+# ai-leverage-daily.sh
+# Daily job: calculates AI leverage and AI rejection rate for an org on GHES.
+# Designed for cron / GitHub Actions. Processes the previous day's closed PRs.
+#
+# Usage: GHES_TOKEN=xxx GHES_HOSTNAME=github.example.com ./ai-leverage-daily.sh MY_ORG
+#
+# Output: JSON report to stdout (pipe to file, dashboard, or artifact)
+
+set -euo pipefail
+
+ORG="${1:?Usage: $0 <org>}"
+SINCE=$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "1 day ago" +%Y-%m-%dT%H:%M:%SZ)
+API="https://${GHES_HOSTNAME}/api/v3"
+AUTH="Authorization: token ${GHES_TOKEN}"
+ACCEPT="Accept: application/vnd.github+json"
+
+TOTAL_MERGED=0
+TOTAL_CLOSED=0
+AI_MERGED=0
+AI_CLOSED=0
+
+# Paginated GET — returns all pages concatenated as a JSON array
+paginate() {
+  local url="$1" page=1 sep="["
+  while true; do
+    local body
+    body=$(curl -s -H "$AUTH" -H "$ACCEPT" "${url}&page=${page}&per_page=100")
+    local count
+    count=$(echo "$body" | jq 'length')
+    echo "$body" | jq -c '.[]' | while read -r item; do echo "${sep}${item}"; sep=","; done
+    [[ "$count" -lt 100 ]] && break
+    ((page++))
+    sleep 0.3
+  done
+  echo "]"
+}
+
+# Check if any commit in a PR has a Copilot trailer
+pr_has_ai() {
+  local repo="$1" pr_num="$2"
+  curl -s -H "$AUTH" -H "$ACCEPT" "$API/repos/$repo/pulls/$pr_num/commits?per_page=100" | \
+    jq -r '[.[].commit.message] | join("\n")' | \
+    grep -qi "co-authored-by:.*copilot" && return 0 || return 1
+}
+
+# Get all repos in the org
+REPOS=$(curl -s -H "$AUTH" -H "$ACCEPT" "$API/orgs/$ORG/repos?type=all&per_page=100" | \
+  jq -r '.[].full_name')
+
+for REPO in $REPOS; do
+  # Fetch PRs closed/merged since yesterday
+  PRS_JSON=$(curl -s -H "$AUTH" -H "$ACCEPT" \
+    "$API/repos/$REPO/pulls?state=closed&sort=updated&direction=desc&per_page=100")
+
+  # Process each PR closed within our window
+  echo "$PRS_JSON" | jq -c --arg since "$SINCE" \
+    '.[] | select(.closed_at >= $since)' | while read -r PR; do
+
+    PR_NUM=$(echo "$PR" | jq -r '.number')
+    MERGED_AT=$(echo "$PR" | jq -r '.merged_at')
+
+    if [[ "$MERGED_AT" != "null" ]]; then
+      ((TOTAL_MERGED++)) || true
+      if pr_has_ai "$REPO" "$PR_NUM"; then
+        ((AI_MERGED++)) || true
+      fi
+    else
+      ((TOTAL_CLOSED++)) || true
+      if pr_has_ai "$REPO" "$PR_NUM"; then
+        ((AI_CLOSED++)) || true
+      fi
+    fi
+    sleep 0.2
+  done
+done
+
+# Output report as JSON
+cat <<EOF
+{
+  "date": "$(date -u +%Y-%m-%d)",
+  "org": "$ORG",
+  "total_merged_prs": $TOTAL_MERGED,
+  "ai_attributed_merged": $AI_MERGED,
+  "ai_leverage_pct": $(echo "scale=1; if ($TOTAL_MERGED > 0) $AI_MERGED * 100 / $TOTAL_MERGED else 0" | bc),
+  "total_closed_without_merge": $TOTAL_CLOSED,
+  "ai_attributed_closed": $AI_CLOSED,
+  "ai_rejection_rate_pct": $(echo "scale=1; a=$AI_MERGED+$AI_CLOSED; if (a > 0) $AI_CLOSED * 100 / a else 0" | bc)
+}
+EOF
 ```
 
-Each commit object includes `commit.message` — check this field for AI co-author trailers.
+**What this measures:**
 
-**Step 3: Check commit messages for AI trailers**
+| Metric | Formula | ESSP zone |
+|---|---|---|
+| AI leverage | AI-attributed merged PRs ÷ total merged PRs | Business Outcomes (Activity) |
+| AI rejection rate | AI-attributed closed-without-merge ÷ all AI-attributed PRs | Quality |
+| PR merge rate | Total merged PRs ÷ total developers | Velocity |
 
-For each commit in the PR, check if `commit.message` contains any of the trailer patterns above. If at least one commit has a match, the PR is "AI-attributed."
-
-**Step 4: Aggregate**
-
-```
-AI Leverage (%) = (PRs with ≥1 AI commit / Total merged PRs) × 100
-```
-
-### Scaling Across the Instance
-
-To run this across all repos in an org (or the entire GHES instance):
-
-- **List all repos**: [`GET /orgs/{org}/repos`](https://docs.github.com/en/enterprise-server@3.21/rest/repos/repos#list-organization-repositories) or [`GET /organizations`](https://docs.github.com/en/enterprise-server@3.21/rest/orgs/orgs#list-organizations) + repos per org
-- **Pagination**: All endpoints return max 100 results per page. Use `Link` header pagination to iterate.
-- **Rate limiting**: GHES rate limits are [disabled by default](https://docs.github.com/en/enterprise-server@3.21/rest/search/search) but may be enabled. Check with your GHES site admin.
-- **Commit search shortcut**: The [search commits](https://docs.github.com/en/enterprise-server@3.21/rest/search/search#search-commits) endpoint can find AI-attributed commits across repos in a single query:
-
-```bash
-curl -s -H "Authorization: token $GHES_TOKEN" \
-  -H "Accept: application/vnd.github.cloak-preview+json" \
-  "https://GHES_HOSTNAME/api/v3/search/commits?q=org:MY_ORG+author-date:>2026-05-01+Co-authored-by+Copilot"
-```
+A rising rejection rate for AI-attributed PRs (compared to non-AI PRs) could indicate that AI-generated code isn't passing review — worth investigating with the team before drawing conclusions.
 
 > [!NOTE]
-> Search returns max 1,000 results. For large orgs, use the per-repo PR + commits approach above.
-
-### Recommended Automation
-
-Run this as a scheduled GitHub Actions workflow on GHES (or a cron job) that:
-- Queries all repos in the org for merged PRs in the last 7/30 days
-- Checks each PR's commits for AI trailers
-- Outputs a report: total PRs, AI-attributed PRs, AI leverage %, broken down by repo and by developer
-- Stores results over time to track trending
+> **Rate limits:** GHES has rate limits [disabled by default](https://docs.github.com/en/enterprise-server@3.21/admin/configuring-settings/configuring-rate-limits/configuring-rate-limits-for-your-instance). If your instance has them enabled, or you're adapting this for GHEC (15,000 requests/hour), a daily cadence keeps volumes manageable — a 1,000-repo org with ~50 PRs closed per day uses roughly 1,000 + 50 = ~1,050 API calls per run.
 
 ---
 
 ## Limitations & Gaps
 
 - **IDE completions are NOT tracked** — This approach only covers agent/CLI sessions where AI makes commits. A developer using Copilot inline suggestions in the editor gets no trailer. The `"all"` value for `git.addAICoAuthor` attempts to cover completions, but detection accuracy for inline completions is lower than for agent/chat edits.
-- **`git.addAICoAuthor` is not enforceable** — It's a regular VS Code setting, not an [enterprise policy](https://code.visualstudio.com/docs/enterprise/policies). Developers can override it. Same constraint as OTel monitoring.
-- **Trailers are removable** — Developers can edit commit messages or use `--no-verify` to skip hooks. This is an honesty system.
+- **`git.addAICoAuthor` is not enforceable** — It's a regular VS Code setting, not an [enterprise policy](https://code.visualstudio.com/docs/enterprise/policies). Developers can override it.
+- **Trailers are removable** — Developers can edit commit messages before pushing. This is an honesty system.
 - **False positives are possible** — VS Code's `git.addAICoAuthor` [historically tagged commits even when AI wasn't actually used](https://github.com/microsoft/vscode/pull/310226) (part of why it was reverted from default-on)
 - **No standard trailer yet** — Industry is split between `Co-authored-by`, `Assisted-by`, and `AI-Generated-By`. The Linux kernel is exploring `Assisted-by`. Microsoft is tracking this in [vscode#313962](https://github.com/microsoft/vscode/issues/313962).
 - **Cross-tool inconsistency** — Different tools use different trailer formats and email addresses, requiring broad grep patterns
@@ -271,7 +281,7 @@ For comparison, GitHub Enterprise Cloud provides native metrics via the [Copilot
 | Time-to-merge comparison | DIY calculation | `median_minutes_to_merge_copilot_authored` |
 | Copilot code review tracking | Not available | `total_merged_reviewed_by_copilot` |
 | Per-user AI engagement | Not available | [Per-user metrics endpoints](https://docs.github.com/en/enterprise-cloud@latest/copilot/reference/copilot-usage-metrics/copilot-usage-metrics) |
-| Configuration required | VS Code settings + hooks (overridable) | None — works out of the box |
+| Configuration required | VS Code setting (overridable) | None — works out of the box |
 | Accuracy | Depends on trailer presence (honesty system) | Server-side tracking (100% for coding agent) |
 
 The native Cloud/EMU metrics track at the platform level. No client configuration, no trailers to manage, no opt-out risk.
@@ -280,8 +290,7 @@ The native Cloud/EMU metrics track at the platform level. No client configuratio
 
 ## Recommended Implementation Order
 
-1. Commit `.vscode/settings.json` with `"git.addAICoAuthor": "all"` to repositories (immediate, covers the most common agent workflow)
+1. **Test locally** — set `"git.addAICoAuthor": "all"` in your own VS Code settings and verify trailers appear on commits from agent mode
 2. Copilot CLI already tags by default — no action needed
-3. For orgs using Claude Code — already tags by default
-4. For orgs using Cursor/Windsurf or wanting a safety net — deploy a `prepare-commit-msg` hook via `core.hooksPath` or a hook manager
-5. Build a periodic query (weekly/monthly) against GHES commit search to track AI PR percentage over time
+3. **Deploy fleet-wide via MDM** — push the setting as a managed default through Intune (see [MDM section above](#deploying-via-mdm-intune-example))
+4. **Set up the daily job** — schedule the AI leverage script as a GitHub Actions workflow or cron to start collecting data

--- a/ai-commit-attribution.md
+++ b/ai-commit-attribution.md
@@ -9,6 +9,7 @@ toc: true
 
 *Last updated: June 19, 2026*
 
+
 How to track which Pull Requests contain AI-authored commits on GitHub Enterprise Server, where Cloud/EMU-only PR metrics are unavailable.
 
 ---
@@ -271,20 +272,66 @@ A rising rejection rate for AI-attributed PRs (compared to non-AI PRs) could ind
 
 ---
 
-## What Cloud/EMU Gives You Instead
+## Measuring the Full Picture: Two Scripts, Two Signals
 
-For comparison, GitHub Enterprise Cloud provides native metrics via the [Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics):
+AI leverage from `ai-leverage-daily.sh` (trailer scanning) captures **all** AI-attributed PRs — including those from the Copilot coding agent, which adds `Co-authored-by: Copilot` trailers to its commits. This gives you the core AI leverage metric on any platform.
 
-| Capability | GHES (this runbook) | Cloud/EMU (native) |
+`copilot-cloud-agent-metrics.sh` adds **metrics you can't get from trailers**: time-to-merge comparisons, code review coverage, suggestion acceptance rates, and daily active user counts. It queries the [Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics), which is only available on Cloud/EMU.
+
+| Script | What it gives you | Platform |
 |---|---|---|
-| AI PR metrics | Manual query via trailers | [`total_merged_created_by_copilot`](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics) |
-| Time-to-merge comparison | DIY calculation | `median_minutes_to_merge_copilot_authored` |
-| Copilot code review tracking | Not available | `total_merged_reviewed_by_copilot` |
-| Per-user AI engagement | Not available | [Per-user metrics endpoints](https://docs.github.com/en/enterprise-cloud@latest/copilot/reference/copilot-usage-metrics/copilot-usage-metrics) |
-| Configuration required | VS Code setting (overridable) | None — works out of the box |
-| Accuracy | Depends on trailer presence (honesty system) | Server-side tracking (100% for coding agent) |
+| `ai-leverage-daily.sh` | AI leverage %, AI rejection rate, multi-tool coverage (Copilot + Claude) | Any (GHES or Cloud) |
+| `copilot-cloud-agent-metrics.sh` | Time-to-merge, code review stats, suggestion acceptance, daily active users | Cloud/EMU only |
 
-The native Cloud/EMU metrics track at the platform level. No client configuration, no trailers to manage, no opt-out risk.
+### When you need which
+
+| Scenario | Scripts needed |
+|---|---|
+| GHES customer | `ai-leverage-daily.sh` only |
+| Cloud/EMU, want AI leverage % only | `ai-leverage-daily.sh` only |
+| Cloud/EMU, want full ESSP metrics (velocity, quality, throughput) | **Both scripts** |
+
+### Real-world example: octodemo (June 18, 2026)
+
+Running both scripts against the same org on the same day:
+
+| Metric | `ai-leverage-daily.sh` | `copilot-cloud-agent-metrics.sh` |
+|---|---|---|
+| Total merged PRs | 23 | 23 |
+| AI-attributed merged | **8 (34.8%)** | **2 (8.7%)** |
+| AI rejection rate | 11.1% | — |
+| PRs reviewed by Copilot | — | 345 |
+| Median time to merge | — | 0.53 min |
+| Median TTM (Copilot-authored) | — | 10.25 min |
+| Daily active Copilot users | — | 812 |
+
+The trailer script found 8 AI PRs (including coding agent PRs). The Metrics API found only 2 `total_merged_created_by_copilot` — a narrower count that only includes PRs the coding agent fully created. The trailer script's higher number reflects IDE/CLI AI usage plus coding agent, giving the broader AI leverage picture.
+
+### What the Copilot Metrics API adds beyond trailers
+
+| Capability | `ai-leverage-daily.sh` | `copilot-cloud-agent-metrics.sh` |
+|---|---|---|
+| AI leverage (all tools) | ✅ | — (narrower: coding agent only) |
+| Coding agent PRs | ✅ (via trailer) | ✅ `total_merged_created_by_copilot` |
+| Time-to-merge comparison | ❌ | ✅ `median_minutes_to_merge_copilot_authored` |
+| Copilot code review | ❌ | ✅ `total_merged_reviewed_by_copilot` |
+| Review suggestion acceptance | ❌ | ✅ `total_copilot_applied_suggestions` |
+| Multi-tool coverage (Claude, etc.) | ✅ | ❌ Copilot only |
+| AI rejection rate | ✅ | ❌ |
+| Daily active users | ❌ | ✅ |
+| Works on GHES | ✅ | ❌ Cloud/EMU only |
+
+See [ai-commit-attribution/ghes-vs-cloud-comparison.md](./ai-commit-attribution/ghes-vs-cloud-comparison.md) for the detailed analysis.
+
+### Scripts
+
+Both scripts are in the [ai-commit-attribution/scripts/](./ai-commit-attribution/scripts/) directory:
+
+- **[`ai-leverage-daily.sh`](./ai-commit-attribution/scripts/ai-leverage-daily.sh)** — trailer scanning for IDE/CLI AI usage (any platform)
+- **[`copilot-cloud-agent-metrics.sh`](./ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh)** — Copilot coding agent + code review metrics (Cloud/EMU only)
+- **[`generate-installation-token.sh`](./ai-commit-attribution/scripts/generate-installation-token.sh)** — GitHub App token generation
+
+See [ai-commit-attribution/github-app-setup.md](./ai-commit-attribution/github-app-setup.md) for GitHub App setup instructions (recommended for large orgs due to the 15,000 req/hr rate limit vs 5,000 for PATs).
 
 ---
 
@@ -293,4 +340,5 @@ The native Cloud/EMU metrics track at the platform level. No client configuratio
 1. **Test locally** — set `"git.addAICoAuthor": "all"` in your own VS Code settings and verify trailers appear on commits from agent mode
 2. Copilot CLI already tags by default — no action needed
 3. **Deploy fleet-wide via MDM** — push the setting as a managed default through Intune (see [MDM section above](#deploying-via-mdm-intune-example))
-4. **Set up the daily job** — schedule the AI leverage script as a GitHub Actions workflow or cron to start collecting data
+4. **Set up the daily job** — schedule `ai-leverage-daily.sh` as a GitHub Actions workflow or cron
+5. **If using Copilot coding agent or PR review on Cloud** — add `copilot-cloud-agent-metrics.sh` to your daily job to capture platform-level metrics

--- a/ai-commit-attribution.md
+++ b/ai-commit-attribution.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Measuring AI in Pull Requests (Not Lines of Code)
+description: Measure AI's contribution to merged PRs with trailer scanning and the Copilot usage metrics API
 toc: true
 ---
 
@@ -8,9 +9,6 @@ toc: true
 {:.no_toc}
 
 *Last updated: June 19, 2026*
-
-
-A practical way to answer "how much are we using AI?" by measuring AI's contribution to Pull Requests instead of counting lines of code.
 
 ---
 
@@ -45,7 +43,7 @@ There are two ways to detect AI involvement in a PR, and you need both because t
 AI tools can add a `Co-authored-by` [trailer](https://docs.github.com/en/enterprise-cloud@latest/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) to commit messages. This is a standard Git feature. If the trailer lands on a commit, you can scan for it later. This catches IDE (VS Code) and Copilot CLI usage, and the Copilot coding agent too, since the agent tags its own commits.
 
 **2. The Copilot usage metrics API (Cloud/EMU only).**
-GitHub tracks the Copilot coding agent and Copilot code review server-side and exposes the counts through the [Copilot usage metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics). No trailers, no client configuration. The coding agent already shows up in the trailer scan, but the API gives you its exact count separately, plus review coverage and time-to-merge that trailers cannot provide.
+GitHub tracks the Copilot coding agent and Copilot code review server-side and exposes the counts through the [Copilot usage metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics). No trailers, no client configuration. The coding agent already shows up in the trailer scan, but the API gives you its exact count separately, plus review coverage and suggestion acceptance that the trailer scan cannot derive.
 
 Which detection method you need depends on which Copilot features are in play. That is what the two scripts below are for.
 
@@ -57,12 +55,12 @@ This guide ships two example scripts. Run one or both depending on which Copilot
 
 | Script | What it measures | When you need it |
 |---|---|---|
-| `ai-leverage-daily.sh` | AI leverage % and AI rejection rate by scanning `Co-authored-by` trailers (Copilot CLI, VS Code, Claude Code) | **Always.** This is the only way to see IDE and CLI AI usage. |
-| `copilot-cloud-agent-metrics.sh` | Coding agent PRs, code review coverage, suggestion acceptance, time-to-merge, daily active users | **Add it if you are on Cloud/EMU** and use the Copilot coding agent or Copilot code review. |
+| `ai-leverage-daily.sh` | AI leverage %, AI rejection rate, and median time-to-merge by scanning `Co-authored-by` trailers (Copilot CLI, VS Code, Claude Code) | **Always.** This is the only way to see IDE and CLI AI usage. |
+| `copilot-cloud-agent-metrics.sh` | Coding agent PRs, code review coverage, suggestion acceptance, daily active users | **Add it if you are on Cloud/EMU** and use the Copilot coding agent or Copilot code review. |
 
-`ai-leverage-daily.sh` is the baseline. Trailers are the only signal that captures a developer using Copilot in their editor or in the CLI, and that usage is invisible to the metrics API. Start here regardless of platform.
+`ai-leverage-daily.sh` is the baseline. Trailers are the only signal that captures a developer using Copilot in their editor or in the CLI, and that usage is invisible to the metrics API. It also computes median time-to-merge straight from each PR's `created_at` and `merged_at` timestamps, so you get PR velocity on any GitHub edition. Start here regardless of platform.
 
-`copilot-cloud-agent-metrics.sh` adds two things. First, it isolates the Copilot coding agent subset of your PRs, which you can subtract from the trailer total to see how much leverage comes from IDE and CLI usage. Second, it reports metrics trailers cannot provide at all: code review coverage, suggestion acceptance, and velocity numbers like time-to-merge. It only works on Cloud/EMU because the usage metrics API is Cloud-only.
+`copilot-cloud-agent-metrics.sh` adds two things. First, it isolates the Copilot coding agent subset of your PRs, which you can subtract from the trailer total to see how much leverage comes from IDE and CLI usage. Second, it reports metrics the trailer scan cannot derive: code review coverage, suggestion acceptance, daily active users, and a server-side time-to-merge pre-scoped to coding-agent PRs. It only works on Cloud/EMU because the usage metrics API is Cloud-only.
 
 > [!NOTE]
 > The scripts are example implementations meant for manual testing and as a starting point you can adapt. For ongoing measurement, run them on a daily schedule in whatever pipeline you already use. See [Running it on a schedule](#running-it-on-a-schedule).
@@ -88,8 +86,10 @@ This script finds recently closed PRs, then checks each one's commits for an AI 
 | Step | Endpoint | Docs |
 |---|---|---|
 | Find closed PRs in the org and time window | `GET /search/issues` | [Search issues and pull requests](https://docs.github.com/en/enterprise-cloud@latest/rest/search/search#search-issues-and-pull-requests) |
-| Get a PR's merge status (`merged_at` vs `closed_at`) | `GET /repos/{owner}/{repo}/pulls/{pull_number}` | [Get a pull request](https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls#get-a-pull-request) |
+| Get a PR's merge status and timestamps (`created_at`, `merged_at`, `closed_at`) | `GET /repos/{owner}/{repo}/pulls/{pull_number}` | [Get a pull request](https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls#get-a-pull-request) |
 | List a PR's commits to scan trailers | `GET /repos/{owner}/{repo}/pulls/{pull_number}/commits` | [List commits on a pull request](https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls#list-commits-on-a-pull-request) |
+
+The same PR response carries `created_at` and `merged_at`, so the script computes median time-to-merge locally — no Cloud-only API required.
 
 It needs read access to repository contents and pull requests (`repo` scope on a PAT, or Contents + Pull requests read on a GitHub App).
 
@@ -129,10 +129,12 @@ Trailer scanning only finds what is tagged. Copilot CLI tags commits by default,
 | **Copilot CLI** | Yes | `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` |
 | **VS Code agent mode** | No (opt-in) | `Co-authored-by: Copilot <copilot@github.com>` |
 | **Claude Code** | Yes | `Co-Authored-By: Claude <noreply@anthropic.com>` |
-| **Cursor agent** | No | none |
+| **Cursor agent** | Yes | `Made with Cursor` (not `Co-authored-by` format) |
 | **Windsurf agent** | No | none |
 
 VS Code shipped the setting default-on for a few weeks in spring 2026 ([PR 310226](https://github.com/microsoft/vscode/pull/310226) flipped the default to `all`), then walked it back to `off` ([PR 313931](https://github.com/microsoft/vscode/pull/313931)) after a debate over what `Co-authored-by` should mean for an AI. It is opt-in again today. Note the two different Copilot emails: the CLI uses the GitHub noreply address, while the VS Code setting uses `copilot@github.com`. Your scan pattern has to match both. The script uses `co-authored-by:.*(copilot|claude)`, which catches all of them.
+
+**Cursor is a special case.** Cursor's Agent does tag commits by default — its CLI config field [`attribution.attributeCommitsToAgent`](https://cursor.com/docs/cli/reference/configuration) defaults to `true` and adds a `Made with Cursor` trailer (with a matching `Made with Cursor` footer on PRs via `attributePRsToAgent`). The catch is the format: it is a `Made with Cursor` line, not a `Co-authored-by` trailer, so the default scan pattern above does **not** catch it. If your developers use Cursor, extend the scan to also match `made with cursor`. Cursor users can disable the trailer in Settings → Agents → Attribution, or by setting `attributeCommitsToAgent` to `false` in `~/.cursor/cli-config.json`.
 
 ### The VS Code setting
 
@@ -206,7 +208,7 @@ if (Test-Path $settingsPath) {
 ```
 
 > [!IMPORTANT]
-> Cursor and Windsurf do not add AI attribution trailers and do not expose a signal you can detect externally. Commits from those tools will not show up in your AI leverage number unless the developer adds a trailer by hand.
+> Cursor's Agent tags commits with a `Made with Cursor` trailer by default, but it is not in `Co-authored-by` format, so the default scan pattern misses it unless you extend the pattern to also match `made with cursor`. Windsurf does not add any AI attribution trailer and exposes no externally detectable signal, so its commits will not show up in your AI leverage number unless the developer adds a trailer by hand.
 
 ---
 
@@ -237,7 +239,9 @@ Output (stdout is clean JSON; progress goes to stderr):
   "ai_leverage_pct": 34.8,
   "total_closed_without_merge": 46,
   "ai_attributed_closed": 1,
-  "ai_rejection_rate_pct": 11.1
+  "ai_rejection_rate_pct": 11.1,
+  "median_time_to_merge_min": 142.5,
+  "median_ai_time_to_merge_min": 98.3
 }
 ```
 
@@ -245,6 +249,10 @@ Output (stdout is clean JSON; progress goes to stderr):
 |---|---|---|
 | AI leverage | AI-attributed merged PRs ÷ total merged PRs | Activity |
 | AI rejection rate | AI-attributed closed-without-merge ÷ all AI-attributed PRs | Quality |
+| Median time to merge | Median of `merged_at − created_at` across merged PRs | Velocity |
+| AI vs human velocity | `median_ai_time_to_merge_min` vs `median_time_to_merge_min` | Velocity |
+
+Time-to-merge comes from each PR's own `created_at` and `merged_at`, which the standard pulls API returns on any GitHub edition, so the baseline script reports velocity without the Cloud-only metrics API. Both medians are `null` when nothing merged in the window.
 
 A rising rejection rate for AI PRs, compared to non-AI PRs, can mean AI-generated code is not passing review. Treat it as a prompt to talk to the team, not a conclusion.
 
@@ -265,7 +273,7 @@ Pulls Copilot coding agent and code review metrics from the usage metrics API.
 ./ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh octodemo --enterprise my-enterprise --28day
 ```
 
-The coding agent adds a `Co-authored-by: Copilot` trailer too, so its PRs already count toward the trailer scan's total. What this script adds is the breakdown. The coding-agent-only count (`total_merged_created_by_copilot`) lets you subtract that subset from the trailer total to see how much of your AI leverage comes from IDE, CLI, and Claude instead. It also reports things trailers cannot show at all: code review coverage (`total_reviewed_by_copilot`), suggestion acceptance, median time-to-merge, and daily active users. See the [scripts README](./ai-commit-attribution/README.md) for the full output schema and ESSP mapping.
+The coding agent adds a `Co-authored-by: Copilot` trailer too, so its PRs already count toward the trailer scan's total. What this script adds is the breakdown. The coding-agent-only count (`total_merged_created_by_copilot`) lets you subtract that subset from the trailer total to see how much of your AI leverage comes from IDE, CLI, and Claude instead. It also reports things the trailer scan cannot derive: code review coverage (`total_reviewed_by_copilot`), suggestion acceptance, daily active users, and a server-side time-to-merge pre-scoped to coding-agent PRs. (Overall and AI-attributed time-to-merge for all PRs already comes from the baseline scan.) See the [scripts README](./ai-commit-attribution/README.md) for the full output schema and ESSP mapping.
 
 ### Running it on a schedule
 
@@ -290,11 +298,11 @@ Trailer scanning counts **any** PR with an AI co-author, so it is the superset f
 | AI-attributed merged | 8 (34.8%) | 2 (8.7%) |
 | AI rejection rate | 11.1% | — |
 | PRs reviewed by Copilot | — | 345 |
-| Median time to merge | — | 0.53 min |
-| Median TTM (Copilot-authored) | — | 10.25 min |
+| Median time to merge | 142.5 min | 0.53 min |
+| Median TTM (AI-attributed) | 98.3 min | 10.25 min |
 | Daily active Copilot users | — | 812 |
 
-The trailer scan found 8 AI PRs; the metrics API found 2. Both are right, and the gap is the useful part. The coding agent tags its commits, so its 2 PRs are already inside the trailer scan's 8. Subtract the agent count and you learn that 6 of the 8 came from developers using Copilot in their editor or the CLI. That split is exactly why you run the trailer scan everywhere and add the metrics API when you have coding agent or review activity to break out.
+The trailer scan found 8 AI PRs; the metrics API found 2. Both are right, and the gap is the useful part. The coding agent tags its commits, so its 2 PRs are already inside the trailer scan's 8. Subtract the agent count and you learn that 6 of the 8 came from developers using Copilot in their editor or the CLI. That split is exactly why you run the trailer scan everywhere and add the metrics API when you have coding agent or review activity to break out. The two time-to-merge columns differ because they measure different sets: the baseline median covers every merged PR (and its AI-attributed subset), while the metrics API median is scoped to coding-agent-authored PRs only.
 
 See [ghes-vs-cloud-comparison.md](./ai-commit-attribution/ghes-vs-cloud-comparison.md) for the full side-by-side with real data.
 
@@ -306,6 +314,7 @@ See [ghes-vs-cloud-comparison.md](./ai-commit-attribution/ghes-vs-cloud-comparis
 - **`git.addAICoAuthor` is not enforceable.** It is a regular VS Code setting, not an [enterprise policy](https://code.visualstudio.com/docs/enterprise/policies). Developers can turn it off.
 - **Trailers are removable.** A developer can edit a commit message before pushing. This is an honesty system, not an audit trail.
 - **No standard trailer yet.** The industry is split between `Co-authored-by`, `Assisted-by`, and `AI-Generated-By`. The Linux kernel is looking at `Assisted-by`; Microsoft is tracking it in [vscode#313962](https://github.com/microsoft/vscode/issues/313962).
-- **Cursor and Windsurf are invisible.** Neither tags commits nor exposes a detectable signal.
+- **Cursor uses a non-standard trailer.** Cursor's Agent tags commits with `Made with Cursor` by default ([`attributeCommitsToAgent`](https://cursor.com/docs/cli/reference/configuration) defaults to `true`), but it is not a `Co-authored-by` trailer, so the default scan pattern misses it. Extend the pattern to match `made with cursor` if you have Cursor users, and note developers can disable it.
+- **Windsurf is invisible.** It neither tags commits nor exposes a detectable signal.
 
 None of this makes the number useless. It makes it a directional adoption metric rather than a compliance audit. If you need an enforceable, server-side count, that is what the Copilot usage metrics API gives you on Cloud/EMU, within its narrower coding-agent definition.

--- a/ai-commit-attribution/README.md
+++ b/ai-commit-attribution/README.md
@@ -1,0 +1,216 @@
+# AI Commit Attribution — Scripts
+
+Utility scripts for measuring AI adoption and developer productivity metrics.
+
+| Script | What it gives you | Platform |
+|--------|-------------------|----------|
+| `ai-leverage-daily.sh` | **AI leverage %** and rejection rate by scanning `Co-authored-by` trailers (catches all AI tools: Copilot coding agent, IDE, CLI, Claude Code) | Any (GHES or Cloud) |
+| `copilot-cloud-agent-metrics.sh` | **Additional ESSP metrics**: time-to-merge, code review coverage, suggestion acceptance, daily active users | Cloud/EMU only |
+
+`ai-leverage-daily.sh` is the primary script — it captures all AI-attributed PRs including coding agent PRs (which add trailers). `copilot-cloud-agent-metrics.sh` supplements it with velocity and quality metrics that trailers can't provide.
+
+See [GHES vs Cloud Comparison](./ghes-vs-cloud-comparison.md) for a detailed side-by-side analysis with real data.
+
+---
+
+## ai-leverage-daily.sh
+
+Calculates the percentage of merged PRs that contain AI-authored commits (Copilot CLI, VS Code Copilot, Claude Code) by scanning commit trailers across all repos in a GitHub org.
+
+### Quick Start (PAT auth)
+
+```bash
+# Uses your existing gh CLI auth or GH_TOKEN env var
+./scripts/ai-leverage-daily.sh octodemo
+
+# Scan a specific time window
+./scripts/ai-leverage-daily.sh octodemo --since 2026-06-18T00:00:00Z
+```
+
+### GitHub App Auth (recommended for large orgs)
+
+GitHub App installation tokens provide 15,000 req/hr (vs 5,000 for PATs). See [github-app-setup.md](./github-app-setup.md) for one-time setup.
+
+```bash
+# Using the config file created during setup
+source ~/.config/ai-attribution/config
+
+./scripts/ai-leverage-daily.sh octodemo \
+  --app-id "$APP_ID" \
+  --installation-id "$INSTALLATION_ID" \
+  --private-key "$PRIVATE_KEY_PATH"
+```
+
+### Output
+
+JSON report to stdout:
+```json
+{
+  "date": "2026-06-19",
+  "org": "octodemo",
+  "since": "2026-06-18T19:30:04Z",
+  "prs_checked": 116,
+  "total_merged_prs": 23,
+  "ai_attributed_merged": 8,
+  "ai_leverage_pct": 34.8,
+  "total_closed_without_merge": 46,
+  "ai_attributed_closed": 1,
+  "ai_rejection_rate_pct": 11.1
+}
+```
+
+| Metric | Formula | ESSP Zone |
+|--------|---------|-----------|
+| AI Leverage | AI-merged PRs ÷ total merged PRs | Activity |
+| AI Rejection Rate | AI-closed-without-merge ÷ all AI PRs | Quality |
+
+Progress and debug info goes to stderr, so you can pipe stdout directly:
+```bash
+./scripts/ai-leverage-daily.sh octodemo > report.json
+```
+
+---
+
+## copilot-cloud-agent-metrics.sh
+
+Fetches native Copilot PR metrics from the [Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics). This is the Cloud/EMU equivalent — no trailer scanning needed. Server-side tracking means zero client configuration and 100% accuracy for Copilot coding agent PRs.
+
+### Quick Start
+
+```bash
+# Yesterday's metrics (default)
+./scripts/copilot-cloud-agent-metrics.sh octodemo
+
+# Specific day
+./scripts/copilot-cloud-agent-metrics.sh octodemo --day 2026-06-18
+
+# Last 7 days
+./scripts/copilot-cloud-agent-metrics.sh octodemo --days 7
+
+# 28-day rolling report
+./scripts/copilot-cloud-agent-metrics.sh octodemo --28day
+
+# Enterprise-level instead of org-level
+./scripts/copilot-cloud-agent-metrics.sh octodemo --enterprise my-enterprise --28day
+```
+
+### GitHub App Auth
+
+Same pattern as `ai-leverage-daily.sh`, but the App needs the **Copilot Metrics** permission (org admin access):
+
+```bash
+source ~/.config/ai-attribution/config
+
+./scripts/copilot-cloud-agent-metrics.sh octodemo \
+  --app-id "$APP_ID" \
+  --installation-id "$INSTALLATION_ID" \
+  --private-key "$PRIVATE_KEY_PATH"
+```
+
+> **Note:** The Copilot Metrics API requires org admin or explicit "Copilot usage metrics" access. If your App returns `Resource not accessible by integration`, you need to add the `organization_copilot_seat_management: read` permission to the App or use a PAT with org admin scope.
+
+### Output (daily)
+
+```json
+{
+  "report_type": "daily",
+  "org": "octodemo",
+  "days": [
+    {
+      "day": "2026-06-18",
+      "daily_active_users": 812,
+      "pull_requests": {
+        "total_merged": 23,
+        "total_merged_created_by_copilot": 2,
+        "total_merged_reviewed_by_copilot": 0,
+        "total_created": 396,
+        "total_created_by_copilot": 18,
+        "total_reviewed_by_copilot": 345,
+        "median_minutes_to_merge": 0.53,
+        "median_minutes_to_merge_copilot_authored": 10.25,
+        "total_copilot_suggestions": 103,
+        "total_copilot_applied_suggestions": 2,
+        "ai_leverage_pct": 8.7
+      }
+    }
+  ]
+}
+```
+
+### Output (28-day rolling)
+
+```json
+{
+  "report_type": "28-day rolling",
+  "org": "octodemo",
+  "report_start": "2026-05-22",
+  "report_end": "2026-06-18",
+  "days_with_data": 28,
+  "total_merged_prs": 172,
+  "total_merged_created_by_copilot": 12,
+  "total_merged_reviewed_by_copilot": 0,
+  "total_prs_created": 15039,
+  "total_prs_created_by_copilot": 329,
+  "total_prs_reviewed_by_copilot": 3871,
+  "ai_leverage_pct": 7,
+  "median_minutes_to_merge": 183.66,
+  "median_minutes_to_merge_copilot_authored": 232.96,
+  "total_copilot_review_suggestions": 1097,
+  "total_copilot_applied_suggestions": 17,
+  "avg_daily_active_users": 580
+}
+```
+
+### ESSP Metrics Covered
+
+| Metric | ESSP Zone | Field |
+|--------|-----------|-------|
+| AI Leverage | Activity | `ai_leverage_pct` |
+| PR Velocity (time-to-merge) | Velocity | `median_minutes_to_merge` |
+| AI vs Human velocity delta | Velocity | Compare `median_minutes_to_merge_copilot_authored` vs `median_minutes_to_merge` |
+| Code review coverage | Quality | `total_reviewed_by_copilot` ÷ `total_created` |
+| Review suggestion acceptance | Quality | `total_copilot_applied_suggestions` ÷ `total_copilot_suggestions` |
+| Copilot adoption breadth | Activity | `daily_active_users` |
+
+---
+
+## When You Need Which Script
+
+See [ghes-vs-cloud-comparison.md](./ghes-vs-cloud-comparison.md) for detailed analysis with real octodemo data.
+
+| Scenario | Scripts needed |
+|----------|---------------|
+| GHES customer | `ai-leverage-daily.sh` only |
+| Cloud/EMU, AI leverage % only | `ai-leverage-daily.sh` only |
+| Cloud/EMU, full ESSP metrics (velocity, quality, throughput) | **Both scripts** |
+
+| Dimension | `ai-leverage-daily.sh` | `copilot-cloud-agent-metrics.sh` |
+|-----------|------------------------|----------------------------------|
+| **Primary metric** | AI leverage %, AI rejection rate | Time-to-merge, review coverage, active users |
+| **AI tools covered** | All (Copilot coding agent + IDE + CLI + Claude) | Copilot platform features only |
+| **How** | Scans `Co-authored-by` trailers | Queries Copilot Metrics API |
+| **Platform** | Any (GHES or Cloud) | Cloud/EMU only |
+| **Permissions** | `repo` scope | Org admin or Copilot metrics access |
+| **API cost** | ~100-1000+ calls/day | 1-2 calls/day |
+
+---
+
+## generate-installation-token.sh
+
+Generates a short-lived GitHub App installation token from a private key. Used internally by both scripts when `--app-id` is provided, but can also be called standalone:
+
+```bash
+./scripts/generate-installation-token.sh \
+  --app-id 12345 \
+  --installation-id 67890 \
+  --private-key ~/.config/ai-attribution/octodemo-app.pem
+```
+
+Outputs the token to stdout. Requires only `openssl` and `curl` (no extra dependencies).
+
+---
+
+## GitHub App Setup
+
+See [github-app-setup.md](./github-app-setup.md) for step-by-step instructions on creating and installing the GitHub App used for authentication.
+

--- a/ai-commit-attribution/README.md
+++ b/ai-commit-attribution/README.md
@@ -2,20 +2,28 @@
 
 Utility scripts for measuring AI adoption and developer productivity metrics.
 
-| Script | What it gives you | Platform |
+| Script | What it gives you | When you need it |
 |--------|-------------------|----------|
-| `ai-leverage-daily.sh` | **AI leverage %** and rejection rate by scanning `Co-authored-by` trailers (catches all AI tools: Copilot coding agent, IDE, CLI, Claude Code) | Any (GHES or Cloud) |
-| `copilot-cloud-agent-metrics.sh` | **Additional ESSP metrics**: time-to-merge, code review coverage, suggestion acceptance, daily active users | Cloud/EMU only |
+| `ai-leverage-daily.sh` | **AI leverage %** and rejection rate by scanning `Co-authored-by` trailers (catches all AI tools: Copilot coding agent, IDE, CLI, Claude Code) | Always — the only way to see IDE and CLI usage, any platform |
+| `copilot-cloud-agent-metrics.sh` | **Coding agent + code review metrics**: time-to-merge, review coverage, suggestion acceptance, daily active users | Add it on Cloud/EMU when using the coding agent or Copilot code review |
 
-`ai-leverage-daily.sh` is the primary script — it captures all AI-attributed PRs including coding agent PRs (which add trailers). `copilot-cloud-agent-metrics.sh` supplements it with velocity and quality metrics that trailers can't provide.
+`ai-leverage-daily.sh` is the baseline. Trailers are the only signal that captures a developer using Copilot in their editor or the CLI, so run it regardless of platform. `copilot-cloud-agent-metrics.sh` adds the velocity and quality metrics that trailers can't provide, using server-side data that only exists on Cloud/EMU.
 
-See [GHES vs Cloud Comparison](./ghes-vs-cloud-comparison.md) for a detailed side-by-side analysis with real data.
+See [Trailer Scanning vs Copilot usage metrics API](./ghes-vs-cloud-comparison.md) for a side-by-side with real octodemo data.
 
 ---
 
 ## ai-leverage-daily.sh
 
-Calculates the percentage of merged PRs that contain AI-authored commits (Copilot CLI, VS Code Copilot, Claude Code) by scanning commit trailers across all repos in a GitHub org.
+Calculates the percentage of merged PRs that contain AI-authored commits (Copilot CLI, VS Code Copilot, Claude Code) by scanning commit trailers across a GitHub org. It finds closed PRs through the Search API rather than iterating every repo, so cost scales with the number of closed PRs.
+
+**APIs used:**
+
+| Step | Endpoint | Docs |
+|------|----------|------|
+| Find closed PRs | `GET /search/issues` | [Search issues and pull requests](https://docs.github.com/en/enterprise-cloud@latest/rest/search/search#search-issues-and-pull-requests) |
+| Get PR merge status | `GET /repos/{owner}/{repo}/pulls/{pull_number}` | [Get a pull request](https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls#get-a-pull-request) |
+| List PR commits | `GET /repos/{owner}/{repo}/pulls/{pull_number}/commits` | [List commits on a pull request](https://docs.github.com/en/enterprise-cloud@latest/rest/pulls/pulls#list-commits-on-a-pull-request) |
 
 ### Quick Start (PAT auth)
 
@@ -73,7 +81,16 @@ Progress and debug info goes to stderr, so you can pipe stdout directly:
 
 ## copilot-cloud-agent-metrics.sh
 
-Fetches native Copilot PR metrics from the [Copilot Metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-metrics). This is the Cloud/EMU equivalent — no trailer scanning needed. Server-side tracking means zero client configuration and 100% accuracy for Copilot coding agent PRs.
+Fetches native Copilot PR metrics from the [Copilot usage metrics API](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics). Server-side tracking means zero client configuration and accurate counts for Copilot coding agent PRs. Cloud/EMU only.
+
+**APIs used:** each endpoint returns `download_links` to an NDJSON report that the script downloads and parses. All are documented under [Copilot usage metrics](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics).
+
+| Report | Endpoint |
+|--------|----------|
+| Org, single day | `GET /orgs/{org}/copilot/metrics/reports/organization-1-day?day=YYYY-MM-DD` |
+| Org, 28-day rolling | `GET /orgs/{org}/copilot/metrics/reports/organization-28-day/latest` |
+| Enterprise, single day | `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-1-day?day=YYYY-MM-DD` |
+| Enterprise, 28-day rolling | `GET /enterprises/{enterprise}/copilot/metrics/reports/enterprise-28-day/latest` |
 
 ### Quick Start
 
@@ -107,7 +124,7 @@ source ~/.config/ai-attribution/config
   --private-key "$PRIVATE_KEY_PATH"
 ```
 
-> **Note:** The Copilot Metrics API requires org admin or explicit "Copilot usage metrics" access. If your App returns `Resource not accessible by integration`, you need to add the `organization_copilot_seat_management: read` permission to the App or use a PAT with org admin scope.
+> **Note:** The Copilot usage metrics API requires the **Copilot usage metrics** policy to be enabled, plus org admin, billing manager, or the fine-grained **Organization Copilot metrics** (read) permission. If your App returns `Resource not accessible by integration`, grant it the **Organization Copilot metrics** permission (or use a PAT with org admin scope). See [github-app-setup.md](./github-app-setup.md).
 
 ### Output (daily)
 
@@ -180,18 +197,18 @@ See [ghes-vs-cloud-comparison.md](./ghes-vs-cloud-comparison.md) for detailed an
 
 | Scenario | Scripts needed |
 |----------|---------------|
-| GHES customer | `ai-leverage-daily.sh` only |
+| GHES, or IDE/CLI usage only | `ai-leverage-daily.sh` only |
 | Cloud/EMU, AI leverage % only | `ai-leverage-daily.sh` only |
-| Cloud/EMU, full ESSP metrics (velocity, quality, throughput) | **Both scripts** |
+| Cloud/EMU, using coding agent and/or Copilot code review | **Both scripts** |
 
 | Dimension | `ai-leverage-daily.sh` | `copilot-cloud-agent-metrics.sh` |
 |-----------|------------------------|----------------------------------|
 | **Primary metric** | AI leverage %, AI rejection rate | Time-to-merge, review coverage, active users |
 | **AI tools covered** | All (Copilot coding agent + IDE + CLI + Claude) | Copilot platform features only |
-| **How** | Scans `Co-authored-by` trailers | Queries Copilot Metrics API |
+| **How** | Scans `Co-authored-by` trailers | Queries Copilot usage metrics API |
 | **Platform** | Any (GHES or Cloud) | Cloud/EMU only |
 | **Permissions** | `repo` scope | Org admin or Copilot metrics access |
-| **API cost** | ~100-1000+ calls/day | 1-2 calls/day |
+| **API cost** | ~2 calls per closed PR | 1-2 calls/day |
 
 ---
 
@@ -207,6 +224,8 @@ Generates a short-lived GitHub App installation token from a private key. Used i
 ```
 
 Outputs the token to stdout. Requires only `openssl` and `curl` (no extra dependencies).
+
+**API used:** `POST /app/installations/{installation_id}/access_tokens` — see [Create an installation access token for an app](https://docs.github.com/en/enterprise-cloud@latest/rest/apps/apps#create-an-installation-access-token-for-an-app).
 
 ---
 

--- a/ai-commit-attribution/README.md
+++ b/ai-commit-attribution/README.md
@@ -4,7 +4,7 @@ Utility scripts for measuring AI adoption and developer productivity metrics.
 
 | Script | What it gives you | When you need it |
 |--------|-------------------|----------|
-| `ai-leverage-daily.sh` | **AI leverage %** and rejection rate by scanning `Co-authored-by` trailers (catches all AI tools: Copilot coding agent, IDE, CLI, Claude Code) | Always — the only way to see IDE and CLI usage, any platform |
+| `ai-leverage-daily.sh` | **AI leverage %** and rejection rate by scanning `Co-authored-by` trailers (detects tools that emit trailers: Copilot coding agent, IDE, CLI, Claude Code) | Always — the only way to see IDE and CLI usage, any platform |
 | `copilot-cloud-agent-metrics.sh` | **Coding agent + code review metrics**: time-to-merge, review coverage, suggestion acceptance, daily active users | Add it on Cloud/EMU when using the coding agent or Copilot code review |
 
 `ai-leverage-daily.sh` is the baseline. Trailers are the only signal that captures a developer using Copilot in their editor or the CLI, so run it regardless of platform. `copilot-cloud-agent-metrics.sh` adds the velocity and quality metrics that trailers can't provide, using server-side data that only exists on Cloud/EMU.
@@ -210,7 +210,7 @@ See [ghes-vs-cloud-comparison.md](./ghes-vs-cloud-comparison.md) for detailed an
 | Dimension | `ai-leverage-daily.sh` | `copilot-cloud-agent-metrics.sh` |
 |-----------|------------------------|----------------------------------|
 | **Primary metric** | AI leverage %, AI rejection rate | Time-to-merge, review coverage, active users |
-| **AI tools covered** | All (Copilot coding agent + IDE + CLI + Claude) | Copilot platform features only |
+| **AI tools covered** | Trailer-emitting tools (Copilot coding agent + IDE + CLI + Claude) | Copilot platform features only |
 | **How** | Scans `Co-authored-by` trailers | Queries Copilot usage metrics API |
 | **Platform** | Any (GHES or Cloud) | Cloud/EMU only |
 | **Permissions** | `repo` scope | Org admin or Copilot metrics access |
@@ -229,7 +229,7 @@ Generates a short-lived GitHub App installation token from a private key. Used i
   --private-key ~/.config/ai-attribution/octodemo-app.pem
 ```
 
-Outputs the token to stdout. Requires only `openssl` and `curl` (no extra dependencies).
+Outputs the token to stdout. Requires `openssl`, `curl`, and `jq`.
 
 **API used:** `POST /app/installations/{installation_id}/access_tokens` — see [Create an installation access token for an app](https://docs.github.com/en/enterprise-cloud@latest/rest/apps/apps#create-an-installation-access-token-for-an-app).
 

--- a/ai-commit-attribution/README.md
+++ b/ai-commit-attribution/README.md
@@ -63,7 +63,9 @@ JSON report to stdout:
   "ai_leverage_pct": 34.8,
   "total_closed_without_merge": 46,
   "ai_attributed_closed": 1,
-  "ai_rejection_rate_pct": 11.1
+  "ai_rejection_rate_pct": 11.1,
+  "median_time_to_merge_min": 142.5,
+  "median_ai_time_to_merge_min": 98.3
 }
 ```
 
@@ -71,6 +73,10 @@ JSON report to stdout:
 |--------|---------|-----------|
 | AI Leverage | AI-merged PRs ÷ total merged PRs | Activity |
 | AI Rejection Rate | AI-closed-without-merge ÷ all AI PRs | Quality |
+| PR Velocity (time-to-merge) | Median of `merged_at − created_at` across merged PRs | Velocity |
+| AI vs Human velocity delta | Compare `median_ai_time_to_merge_min` vs `median_time_to_merge_min` | Velocity |
+
+Time-to-merge is computed client-side from the PR's own `created_at` and `merged_at` timestamps, which the standard pulls API returns on **any** GitHub edition (GHES, GHEC, GHEC+EMU). It does not require the Cloud-only usage metrics API. Values are `null` when no PRs merged in the window.
 
 Progress and debug info goes to stderr, so you can pipe stdout directly:
 ```bash

--- a/ai-commit-attribution/ghes-vs-cloud-comparison.md
+++ b/ai-commit-attribution/ghes-vs-cloud-comparison.md
@@ -1,0 +1,192 @@
+---
+layout: default
+title: "GHES vs Cloud: AI Metric Comparison (Octodemo)"
+toc: true
+---
+
+# GHES vs Cloud: AI Metric Comparison
+{:.no_toc}
+
+*Sample run: June 19, 2026 — octodemo org*
+
+A side-by-side comparison of two approaches to measuring AI leverage on the same org, same day:
+
+1. **Trailer scanning** (`ai-leverage-daily.sh`) — the GHES approach, scanning `Co-authored-by` trailers in commit messages via the REST API
+2. **Copilot Metrics API** (`copilot-cloud-agent-metrics.sh`) — the Cloud/EMU approach, using native server-side PR metrics
+
+---
+
+## Raw Output: Same Day (June 18, 2026)
+
+### Trailer Scanning (ai-leverage-daily.sh)
+
+```json
+{
+  "date": "2026-06-19",
+  "org": "octodemo",
+  "since": "2026-06-18T19:30:04Z",
+  "prs_checked": 116,
+  "total_merged_prs": 23,
+  "ai_attributed_merged": 8,
+  "ai_leverage_pct": 34.8,
+  "total_closed_without_merge": 46,
+  "ai_attributed_closed": 1,
+  "ai_rejection_rate_pct": 11.1
+}
+```
+
+### Copilot Metrics API (copilot-cloud-agent-metrics.sh)
+
+```json
+{
+  "report_type": "daily",
+  "org": "octodemo",
+  "days": [
+    {
+      "day": "2026-06-18",
+      "daily_active_users": 812,
+      "pull_requests": {
+        "total_merged": 23,
+        "total_merged_created_by_copilot": 2,
+        "total_merged_reviewed_by_copilot": 0,
+        "total_created": 396,
+        "total_created_by_copilot": 18,
+        "total_reviewed_by_copilot": 345,
+        "median_minutes_to_merge": 0.53,
+        "median_minutes_to_merge_copilot_authored": 10.25,
+        "total_copilot_suggestions": 103,
+        "total_copilot_applied_suggestions": 2,
+        "ai_leverage_pct": 8.7
+      }
+    }
+  ]
+}
+```
+
+---
+
+## Head-to-Head: Key Metrics
+
+| Metric | Trailer Scanning | Copilot Metrics API | Delta |
+|---|---|---|---|
+| Total merged PRs | 23 | 23 | ✅ Match |
+| AI-attributed merged PRs | **8** | **2** | ⚠️ 4× higher via trailers |
+| AI leverage % | **34.8%** | **8.7%** | 26.1pp gap |
+| Closed without merge | 46 | — | Not tracked by Metrics API |
+| AI rejection rate | 11.1% | — | Not tracked by Metrics API |
+| PRs created | — | 396 | Not tracked by trailer scanning |
+| PRs created by Copilot | — | 18 | Not tracked by trailer scanning |
+| PRs reviewed by Copilot | — | 345 | Not tracked by trailer scanning |
+| Median time to merge | — | 0.53 min | Not tracked by trailer scanning |
+| Median TTM (Copilot-authored) | — | 10.25 min | Not tracked by trailer scanning |
+| Code review suggestions | — | 103 | Not tracked by trailer scanning |
+| Daily active users | — | 812 | Not tracked by trailer scanning |
+
+---
+
+## Why Trailer Scanning Shows 4× More AI PRs
+
+The trailer scanner found **8 AI-attributed merged PRs** while the Copilot Metrics API reported only **2**. This is expected:
+
+**Trailer scanning is the superset for AI leverage:**
+- Catches everything: Copilot coding agent PRs (which include trailers), IDE completions (if `git.addAICoAuthor` is on), Copilot CLI, and Claude Code
+- Counts any PR where any commit has a matching `Co-authored-by` trailer
+- The 8 AI PRs include the 2 coding agent PRs plus 6 others from IDE/CLI usage
+
+**Copilot Metrics API `total_merged_created_by_copilot` is a subset:**
+- Only counts PRs **created by the Copilot coding agent** — not all PRs with AI involvement
+- Does not count PRs where a human created the PR but used Copilot in their editor
+- Does not count Claude Code — it's a Copilot-specific metric
+
+**Key takeaway:** Use `ai-leverage-daily.sh` for the AI leverage percentage. Use `copilot-cloud-agent-metrics.sh` for the additional ESSP metrics that trailers can't provide (velocity, review quality, throughput).
+
+---
+
+## ESSP Metric Coverage
+
+The [Engineering System Success Playbook](https://github.com/resources/insights/engineering-system-success-playbook) defines metrics across four zones. Here's what each script covers:
+
+| ESSP Zone | Metric | Trailer Scanning | Copilot Metrics API |
+|---|---|---|---|
+| **Activity** | AI leverage (% merged PRs with AI) | ✅ 34.8% | ✅ 8.7% (narrower definition) |
+| **Activity** | Daily active Copilot users | ❌ | ✅ 812 |
+| **Velocity** | Time to merge | ❌ | ✅ 0.53 min median |
+| **Velocity** | Time to merge (AI-authored) | ❌ | ✅ 10.25 min median |
+| **Quality** | AI rejection rate | ✅ 11.1% | ❌ |
+| **Quality** | Code review (suggestions/applied) | ❌ | ✅ 103 suggestions, 2 applied |
+| **Throughput** | PRs created | ❌ | ✅ 396 total, 18 by Copilot |
+| **Throughput** | PRs reviewed by Copilot | ❌ | ✅ 345 |
+
+### What GHES Customers Miss
+
+Without the Copilot Metrics API, GHES customers cannot measure:
+
+1. **Time-to-merge comparison** — is AI-authored code merging faster or slower? (On octodemo: Copilot-authored PRs take 10.25 min vs 0.53 min median — though this likely reflects different PR complexity rather than AI slowness)
+2. **Copilot code review adoption** — 345 PRs reviewed by Copilot out of 396 created (87% review coverage)
+3. **PR creation volume by Copilot** — 18 PRs created by Copilot coding agent
+4. **Code review suggestion acceptance** — only 2 of 103 suggestions applied (1.9% acceptance rate)
+5. **Daily active Copilot users** — 812 users active on this day
+
+### What GHES Customers Get That Cloud Doesn't Surface
+
+1. **AI rejection rate** — the Metrics API doesn't track closed-without-merge for AI PRs. Trailer scanning found 11.1% rejection rate (1 AI-attributed PR closed without merge out of 9 total AI PRs). This is a quality signal.
+2. **Multi-tool attribution** — trailer scanning catches Claude Code, Copilot CLI, and VS Code agent mode. The Metrics API only tracks Copilot.
+3. **Per-PR granularity** — the trailer script logs each PR individually, so you can see exactly which repos and PRs had AI involvement.
+
+---
+
+## 28-Day Rolling Metrics (Cloud Only)
+
+The Copilot Metrics API also provides a 28-day rolling view not available via trailer scanning:
+
+```json
+{
+  "report_type": "28-day rolling",
+  "org": "octodemo",
+  "report_start": "2026-05-22",
+  "report_end": "2026-06-18",
+  "days_with_data": 28,
+  "total_merged_prs": 172,
+  "total_merged_created_by_copilot": 12,
+  "total_merged_reviewed_by_copilot": 0,
+  "total_prs_created": 15039,
+  "total_prs_created_by_copilot": 329,
+  "total_prs_reviewed_by_copilot": 3871,
+  "ai_leverage_pct": 7,
+  "median_minutes_to_merge": 183.66,
+  "median_minutes_to_merge_copilot_authored": 232.96,
+  "total_copilot_review_suggestions": 1097,
+  "total_copilot_applied_suggestions": 17,
+  "avg_daily_active_users": 580
+}
+```
+
+Over 28 days:
+- **7% AI leverage** (12 of 172 merged PRs created by Copilot)
+- **329 PRs created by Copilot** out of 15,039 total (2.2% of all PRs created)
+- **3,871 PRs reviewed by Copilot** (25.7% of all PRs created)
+- **1,097 review suggestions**, 17 applied (1.5% acceptance rate)
+
+---
+
+## Auth Differences
+
+An important operational difference: the Copilot Metrics API requires **org admin or "Copilot usage metrics" read access**. The GitHub App used for the trailer script (App ID: 4097118) returned `Resource not accessible by integration` when trying the Metrics API — it lacks the required `copilot` permission scope. The data above was fetched using a personal token with org admin access.
+
+Trailer scanning only needs `repo` scope (read access to commits and PRs), which is more commonly available.
+
+---
+
+## Summary
+
+| Dimension | Trailer Scanning (GHES) | Copilot Metrics API (Cloud) |
+|---|---|---|
+| **Setup** | Deploy VS Code setting + daily cron | None — works out of the box |
+| **Accuracy** | Depends on trailers being present (honesty system) | Server-side tracking (100% for coding agent) |
+| **AI tools covered** | Copilot CLI, VS Code agent, Claude Code | Copilot only |
+| **AI definition** | "Any PR with an AI co-author trailer" | "PR created by Copilot coding agent" |
+| **ESSP coverage** | AI leverage + rejection rate | AI leverage + velocity + quality + throughput |
+| **Permissions needed** | `repo` scope | Org admin or Copilot metrics access |
+| **API cost** | ~100-1000+ calls/day (scales with PRs) | 1-2 calls/day |
+
+For GHES customers, trailer scanning is the only option. For Cloud/EMU customers, the Copilot Metrics API provides richer data with zero configuration — but pairing it with trailer scanning gives you multi-tool visibility and the AI rejection rate metric.

--- a/ai-commit-attribution/ghes-vs-cloud-comparison.md
+++ b/ai-commit-attribution/ghes-vs-cloud-comparison.md
@@ -79,8 +79,8 @@ They count different things, so the numbers differ. That difference is the usefu
 | PRs created | — | 396 | Not tracked by trailer scanning |
 | PRs created by Copilot | — | 18 | Not tracked by trailer scanning |
 | PRs reviewed by Copilot | — | 345 | Not tracked by trailer scanning |
-| Median time to merge | — | 0.53 min | Not tracked by trailer scanning |
-| Median TTM (Copilot-authored) | — | 10.25 min | Not tracked by trailer scanning |
+| Median time to merge | 142.5 min | 0.53 min | Different scopes: all merged PRs vs coding-agent PRs |
+| Median TTM (AI-attributed) | 98.3 min | 10.25 min | Trailer scan: any AI co-author; API: coding-agent-authored |
 | Code review suggestions | — | 103 | Not tracked by trailer scanning |
 | Daily active users | — | 812 | Not tracked by trailer scanning |
 
@@ -100,7 +100,7 @@ The trailer scanner found **8 AI-attributed merged PRs** while the Copilot usage
 - Does not count PRs where a human created the PR but used Copilot in their editor
 - Does not count Claude Code — it's a Copilot-specific metric
 
-**Key takeaway:** Use `ai-leverage-daily.sh` for the AI leverage percentage. Use `copilot-cloud-agent-metrics.sh` for the additional ESSP metrics that trailers can't provide (velocity, review quality, throughput).
+**Key takeaway:** Use `ai-leverage-daily.sh` for the AI leverage percentage and PR velocity (time-to-merge, computed from PR timestamps on any platform). Use `copilot-cloud-agent-metrics.sh` for the additional ESSP metrics trailers can't provide (review quality, throughput, coding-agent-scoped velocity).
 
 ---
 
@@ -112,8 +112,8 @@ The [Engineering System Success Playbook](https://github.com/resources/insights/
 |---|---|---|---|
 | **Activity** | AI leverage (% merged PRs with AI) | ✅ 34.8% | ✅ 8.7% (narrower definition) |
 | **Activity** | Daily active Copilot users | ❌ | ✅ 812 |
-| **Velocity** | Time to merge | ❌ | ✅ 0.53 min median |
-| **Velocity** | Time to merge (AI-authored) | ❌ | ✅ 10.25 min median |
+| **Velocity** | Time to merge | ✅ 142.5 min median | ✅ 0.53 min (coding-agent PRs) |
+| **Velocity** | Time to merge (AI-attributed) | ✅ 98.3 min median | ✅ 10.25 min (coding-agent PRs) |
 | **Quality** | AI rejection rate | ✅ 11.1% | ❌ |
 | **Quality** | Code review (suggestions/applied) | ❌ | ✅ 103 suggestions, 2 applied |
 | **Throughput** | PRs created | ❌ | ✅ 396 total, 18 by Copilot |
@@ -123,11 +123,12 @@ The [Engineering System Success Playbook](https://github.com/resources/insights/
 
 Trailer scanning has no view into these. You need the usage metrics API (Cloud/EMU):
 
-1. **Time-to-merge comparison** — is AI-authored code merging faster or slower? (On octodemo: Copilot-authored PRs take 10.25 min vs 0.53 min median — though this likely reflects different PR complexity rather than AI slowness)
-2. **Copilot code review adoption** — 345 PRs reviewed by Copilot out of 396 created (87% review coverage)
-3. **PR creation volume by Copilot** — 18 PRs created by Copilot coding agent
-4. **Code review suggestion acceptance** — only 2 of 103 suggestions applied (1.9% acceptance rate)
-5. **Daily active Copilot users** — 812 users active on this day
+1. **Copilot code review adoption** — 345 PRs reviewed by Copilot out of 396 created (87% review coverage)
+2. **PR creation volume by Copilot** — 18 PRs created by Copilot coding agent
+3. **Code review suggestion acceptance** — only 2 of 103 suggestions applied (1.9% acceptance rate)
+4. **Daily active Copilot users** — 812 users active on this day
+
+The trailer scan *does* compute overall and AI-attributed time-to-merge from each PR's `created_at`/`merged_at`, so velocity is not Cloud-only. The metrics API adds a time-to-merge value pre-scoped to coding-agent-authored PRs, useful when you want that subset broken out without filtering trailers yourself.
 
 ### What the metrics API can't tell you
 
@@ -189,9 +190,9 @@ The trailer scan only needs read access to commits and PRs (`repo` scope), which
 | **Accuracy** | Depends on trailers being present (honesty system) | Server-side tracking (100% for coding agent) |
 | **AI tools covered** | Copilot CLI, VS Code agent, Claude Code | Copilot only |
 | **AI definition** | "Any PR with an AI co-author trailer" | "PR created by Copilot coding agent" |
-| **ESSP coverage** | AI leverage + rejection rate | AI leverage + velocity + quality + throughput |
+| **ESSP coverage** | AI leverage + rejection rate + velocity | AI leverage + velocity + quality + throughput |
 | **Permissions needed** | `repo` scope | Org admin or Copilot metrics access |
 | **Platform** | Any (GHES or Cloud/EMU) | Cloud/EMU only |
 | **API cost** | ~2 calls per closed PR (via Search API) | 1-2 calls/day |
 
-Run the trailer scan everywhere — it is the only way to see IDE and CLI usage, and it works on any platform. On Cloud/EMU, add the usage metrics API when you have coding agent or code review activity to account for. The trailer scan gives you the broad AI leverage number and the rejection rate; the metrics API adds velocity, review quality, and throughput.
+Run the trailer scan everywhere — it is the only way to see IDE and CLI usage, and it works on any platform. It gives you the broad AI leverage number, the rejection rate, and PR velocity (time-to-merge from PR timestamps). On Cloud/EMU, add the usage metrics API when you have coding agent or code review activity to account for; it adds review quality, throughput, and a coding-agent-scoped velocity number.

--- a/ai-commit-attribution/ghes-vs-cloud-comparison.md
+++ b/ai-commit-attribution/ghes-vs-cloud-comparison.md
@@ -1,18 +1,20 @@
 ---
 layout: default
-title: "GHES vs Cloud: AI Metric Comparison (Octodemo)"
+title: "Trailer Scanning vs Copilot usage metrics API (Octodemo)"
 toc: true
 ---
 
-# GHES vs Cloud: AI Metric Comparison
+# Trailer Scanning vs Copilot usage metrics API
 {:.no_toc}
 
 *Sample run: June 19, 2026 — octodemo org*
 
-A side-by-side comparison of two approaches to measuring AI leverage on the same org, same day:
+Two ways to measure AI in Pull Requests, run against the same org on the same day:
 
-1. **Trailer scanning** (`ai-leverage-daily.sh`) — the GHES approach, scanning `Co-authored-by` trailers in commit messages via the REST API
-2. **Copilot Metrics API** (`copilot-cloud-agent-metrics.sh`) — the Cloud/EMU approach, using native server-side PR metrics
+1. **Trailer scanning** (`ai-leverage-daily.sh`) — scans `Co-authored-by` trailers in commit messages via the REST API. Catches IDE and CLI usage on any platform.
+2. **Copilot usage metrics API** (`copilot-cloud-agent-metrics.sh`) — reads server-side PR metrics for the coding agent and code review. Cloud/EMU only.
+
+They count different things, so the numbers differ. That difference is the useful part.
 
 ---
 
@@ -35,7 +37,7 @@ A side-by-side comparison of two approaches to measuring AI leverage on the same
 }
 ```
 
-### Copilot Metrics API (copilot-cloud-agent-metrics.sh)
+### Copilot usage metrics API (copilot-cloud-agent-metrics.sh)
 
 ```json
 {
@@ -67,7 +69,7 @@ A side-by-side comparison of two approaches to measuring AI leverage on the same
 
 ## Head-to-Head: Key Metrics
 
-| Metric | Trailer Scanning | Copilot Metrics API | Delta |
+| Metric | Trailer Scanning | Copilot usage metrics API | Delta |
 |---|---|---|---|
 | Total merged PRs | 23 | 23 | ✅ Match |
 | AI-attributed merged PRs | **8** | **2** | ⚠️ 4× higher via trailers |
@@ -86,14 +88,14 @@ A side-by-side comparison of two approaches to measuring AI leverage on the same
 
 ## Why Trailer Scanning Shows 4× More AI PRs
 
-The trailer scanner found **8 AI-attributed merged PRs** while the Copilot Metrics API reported only **2**. This is expected:
+The trailer scanner found **8 AI-attributed merged PRs** while the Copilot usage metrics API reported only **2**. This is expected:
 
 **Trailer scanning is the superset for AI leverage:**
 - Catches everything: Copilot coding agent PRs (which include trailers), IDE completions (if `git.addAICoAuthor` is on), Copilot CLI, and Claude Code
 - Counts any PR where any commit has a matching `Co-authored-by` trailer
 - The 8 AI PRs include the 2 coding agent PRs plus 6 others from IDE/CLI usage
 
-**Copilot Metrics API `total_merged_created_by_copilot` is a subset:**
+**Copilot usage metrics API `total_merged_created_by_copilot` is a subset:**
 - Only counts PRs **created by the Copilot coding agent** — not all PRs with AI involvement
 - Does not count PRs where a human created the PR but used Copilot in their editor
 - Does not count Claude Code — it's a Copilot-specific metric
@@ -106,7 +108,7 @@ The trailer scanner found **8 AI-attributed merged PRs** while the Copilot Metri
 
 The [Engineering System Success Playbook](https://github.com/resources/insights/engineering-system-success-playbook) defines metrics across four zones. Here's what each script covers:
 
-| ESSP Zone | Metric | Trailer Scanning | Copilot Metrics API |
+| ESSP Zone | Metric | Trailer Scanning | Copilot usage metrics API |
 |---|---|---|---|
 | **Activity** | AI leverage (% merged PRs with AI) | ✅ 34.8% | ✅ 8.7% (narrower definition) |
 | **Activity** | Daily active Copilot users | ❌ | ✅ 812 |
@@ -117,9 +119,9 @@ The [Engineering System Success Playbook](https://github.com/resources/insights/
 | **Throughput** | PRs created | ❌ | ✅ 396 total, 18 by Copilot |
 | **Throughput** | PRs reviewed by Copilot | ❌ | ✅ 345 |
 
-### What GHES Customers Miss
+### What the trailer scan can't tell you
 
-Without the Copilot Metrics API, GHES customers cannot measure:
+Trailer scanning has no view into these. You need the usage metrics API (Cloud/EMU):
 
 1. **Time-to-merge comparison** — is AI-authored code merging faster or slower? (On octodemo: Copilot-authored PRs take 10.25 min vs 0.53 min median — though this likely reflects different PR complexity rather than AI slowness)
 2. **Copilot code review adoption** — 345 PRs reviewed by Copilot out of 396 created (87% review coverage)
@@ -127,7 +129,9 @@ Without the Copilot Metrics API, GHES customers cannot measure:
 4. **Code review suggestion acceptance** — only 2 of 103 suggestions applied (1.9% acceptance rate)
 5. **Daily active Copilot users** — 812 users active on this day
 
-### What GHES Customers Get That Cloud Doesn't Surface
+### What the metrics API can't tell you
+
+The usage metrics API has no view into these. You need the trailer scan:
 
 1. **AI rejection rate** — the Metrics API doesn't track closed-without-merge for AI PRs. Trailer scanning found 11.1% rejection rate (1 AI-attributed PR closed without merge out of 9 total AI PRs). This is a quality signal.
 2. **Multi-tool attribution** — trailer scanning catches Claude Code, Copilot CLI, and VS Code agent mode. The Metrics API only tracks Copilot.
@@ -137,7 +141,7 @@ Without the Copilot Metrics API, GHES customers cannot measure:
 
 ## 28-Day Rolling Metrics (Cloud Only)
 
-The Copilot Metrics API also provides a 28-day rolling view not available via trailer scanning:
+The Copilot usage metrics API also provides a 28-day rolling view not available via trailer scanning:
 
 ```json
 {
@@ -169,24 +173,25 @@ Over 28 days:
 
 ---
 
-## Auth Differences
+## Auth differences
 
-An important operational difference: the Copilot Metrics API requires **org admin or "Copilot usage metrics" read access**. The GitHub App used for the trailer script (App ID: 4097118) returned `Resource not accessible by integration` when trying the Metrics API — it lacks the required `copilot` permission scope. The data above was fetched using a personal token with org admin access.
+The two methods need different access. The usage metrics API requires **org admin, billing manager, or "View Copilot Metrics" access**. The GitHub App used for the trailer script (App ID: 4097118) returned `Resource not accessible by integration` against the metrics API because it lacks the `copilot` permission scope, so the metrics data above was fetched with a personal token that has org admin access.
 
-Trailer scanning only needs `repo` scope (read access to commits and PRs), which is more commonly available.
+The trailer scan only needs read access to commits and PRs (`repo` scope), which is easier to get.
 
 ---
 
 ## Summary
 
-| Dimension | Trailer Scanning (GHES) | Copilot Metrics API (Cloud) |
+| Dimension | Trailer scanning | Copilot usage metrics API |
 |---|---|---|
-| **Setup** | Deploy VS Code setting + daily cron | None — works out of the box |
+| **Setup** | Deploy VS Code setting + daily job | None — works out of the box |
 | **Accuracy** | Depends on trailers being present (honesty system) | Server-side tracking (100% for coding agent) |
 | **AI tools covered** | Copilot CLI, VS Code agent, Claude Code | Copilot only |
 | **AI definition** | "Any PR with an AI co-author trailer" | "PR created by Copilot coding agent" |
 | **ESSP coverage** | AI leverage + rejection rate | AI leverage + velocity + quality + throughput |
 | **Permissions needed** | `repo` scope | Org admin or Copilot metrics access |
-| **API cost** | ~100-1000+ calls/day (scales with PRs) | 1-2 calls/day |
+| **Platform** | Any (GHES or Cloud/EMU) | Cloud/EMU only |
+| **API cost** | ~2 calls per closed PR (via Search API) | 1-2 calls/day |
 
-For GHES customers, trailer scanning is the only option. For Cloud/EMU customers, the Copilot Metrics API provides richer data with zero configuration — but pairing it with trailer scanning gives you multi-tool visibility and the AI rejection rate metric.
+Run the trailer scan everywhere — it is the only way to see IDE and CLI usage, and it works on any platform. On Cloud/EMU, add the usage metrics API when you have coding agent or code review activity to account for. The trailer scan gives you the broad AI leverage number and the rejection rate; the metrics API adds velocity, review quality, and throughput.

--- a/ai-commit-attribution/github-app-setup.md
+++ b/ai-commit-attribution/github-app-setup.md
@@ -1,0 +1,129 @@
+# GitHub App Setup: AI Commit Attribution
+
+This guide walks through creating and installing a GitHub App for the `ai-leverage-daily.sh` script. The App provides 15,000 API requests/hour (vs 5,000 for a PAT) and uses short-lived tokens.
+
+---
+
+## Prerequisites
+
+- **Org admin access** to `octodemo` (or your target org)
+- `openssl` installed locally (pre-installed on macOS)
+
+---
+
+## Step 1: Create the GitHub App
+
+1. Go to: **https://github.com/organizations/octodemo/settings/apps/new**
+
+2. Fill in the form:
+
+   | Field | Value |
+   |-------|-------|
+   | **GitHub App name** | `AI Commit Attribution` |
+   | **Description** | Measures AI leverage across org repos by scanning commit trailers |
+   | **Homepage URL** | `https://github.com/octodemo/octocat_supply-glorious-fishstick` |
+
+3. Under **Webhook**:
+   - **Uncheck** "Active" (we don't need webhook events)
+
+4. Under **Permissions → Repository permissions**:
+   - **Contents**: Read-only
+   - **Pull requests**: Read-only
+   - **Metadata**: Read-only (auto-selected)
+
+5. Under **Where can this GitHub App be installed?**:
+   - Select **Only on this account**
+
+6. Click **Create GitHub App**
+
+7. **Note the App ID** shown on the next page (you'll need this)
+
+---
+
+## Step 2: Generate a Private Key
+
+1. On the App settings page, scroll to **Private keys**
+2. Click **Generate a private key**
+3. A `.pem` file downloads automatically
+4. Move it to a secure location:
+
+```bash
+mkdir -p ~/.config/ai-attribution
+mv ~/Downloads/ai-commit-attribution.*.pem ~/.config/ai-attribution/octodemo-app.pem
+chmod 600 ~/.config/ai-attribution/octodemo-app.pem
+```
+
+---
+
+## Step 3: Install the App
+
+1. Go to: **https://github.com/organizations/octodemo/settings/apps** (or click "Install App" in the left sidebar of your App's settings)
+2. Click **Install** next to your App
+3. Select **All repositories**
+4. Click **Install**
+5. **Note the Installation ID** from the URL: `https://github.com/organizations/octodemo/settings/installations/<INSTALLATION_ID>`
+
+---
+
+## Step 4: Store Configuration
+
+Create a config file for easy invocation:
+
+```bash
+cat > ~/.config/ai-attribution/config << EOF
+APP_ID=<your-app-id>
+INSTALLATION_ID=<your-installation-id>
+PRIVATE_KEY_PATH=~/.config/ai-attribution/octodemo-app.pem
+EOF
+```
+
+---
+
+## Step 5: Run the Script
+
+The main script handles token generation automatically — just pass the App credentials:
+
+```bash
+./scripts/ai-leverage-daily.sh octodemo \
+  --app-id <APP_ID> \
+  --installation-id <INSTALLATION_ID> \
+  --private-key ~/.config/ai-attribution/octodemo-app.pem
+```
+
+Or, using the config file created in Step 4:
+
+```bash
+source ~/.config/ai-attribution/config
+./scripts/ai-leverage-daily.sh octodemo \
+  --app-id "$APP_ID" \
+  --installation-id "$INSTALLATION_ID" \
+  --private-key "$PRIVATE_KEY_PATH"
+```
+
+> **Note:** You do NOT need to run `generate-installation-token.sh` separately — `ai-leverage-daily.sh` calls it internally. The standalone script exists only if you need a token for other tools (e.g., `curl`, `gh` CLI):
+> ```bash
+> export GH_TOKEN=$(./scripts/generate-installation-token.sh \
+>   --app-id <APP_ID> --installation-id <INSTALLATION_ID> \
+>   --private-key ~/.config/ai-attribution/octodemo-app.pem)
+> gh api /orgs/octodemo/repos --jq '.[].name' | head
+> ```
+
+---
+
+## Rate Limits
+
+| Auth Method | Rate Limit | Notes |
+|-------------|-----------|-------|
+| Personal Access Token | 5,000/hr | Shared across all your PAT usage |
+| GitHub App (installation token) | 15,000/hr | Dedicated to this App |
+
+A full octodemo scan (~4,100 API calls) uses **27%** of the App's hourly budget vs **82%** of a PAT's.
+
+---
+
+## Security Notes
+
+- The private key **never** goes into the repository
+- Installation tokens expire after **1 hour**
+- The App has **read-only** access — it cannot modify any code or PRs
+- If the key is compromised, revoke it from the App settings page and generate a new one

--- a/ai-commit-attribution/github-app-setup.md
+++ b/ai-commit-attribution/github-app-setup.md
@@ -1,6 +1,8 @@
 # GitHub App Setup: AI Commit Attribution
 
-This guide walks through creating and installing a GitHub App for the `ai-leverage-daily.sh` script. The App provides 15,000 API requests/hour (vs 5,000 for a PAT) and uses short-lived tokens.
+This guide walks through creating and installing a GitHub App for the AI attribution scripts. The App provides 15,000 API requests/hour (vs 5,000 for a PAT) and uses short-lived tokens.
+
+The permissions you grant depend on which scripts you run. `ai-leverage-daily.sh` needs repository read access. `copilot-cloud-agent-metrics.sh` additionally needs the Copilot metrics permission. Both are covered in Step 1.
 
 ---
 
@@ -26,10 +28,15 @@ This guide walks through creating and installing a GitHub App for the `ai-levera
 3. Under **Webhook**:
    - **Uncheck** "Active" (we don't need webhook events)
 
-4. Under **Permissions → Repository permissions**:
+4. Under **Permissions → Repository permissions** (required for `ai-leverage-daily.sh`):
    - **Contents**: Read-only
    - **Pull requests**: Read-only
    - **Metadata**: Read-only (auto-selected)
+
+   Under **Permissions → Organization permissions** (only if you also run `copilot-cloud-agent-metrics.sh`):
+   - **Organization Copilot metrics**: Read-only
+
+   > For enterprise-level metrics (the `--enterprise` flag), the org permission above is not enough. The App must be installed on the enterprise and granted **View Enterprise Copilot Metrics**, and the "Copilot usage metrics" policy must be enabled for the enterprise. See [Copilot usage metrics](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics).
 
 5. Under **Where can this GitHub App be installed?**:
    - Select **Only on this account**
@@ -108,6 +115,20 @@ source ~/.config/ai-attribution/config
 > gh api /orgs/octodemo/repos --jq '.[].name' | head
 > ```
 
+### Running the metrics script
+
+The same App credentials work for `copilot-cloud-agent-metrics.sh`, as long as you granted the **Organization Copilot metrics** permission in Step 1 and the **Copilot usage metrics** policy is enabled for the org (or enterprise):
+
+```bash
+source ~/.config/ai-attribution/config
+./scripts/copilot-cloud-agent-metrics.sh octodemo \
+  --app-id "$APP_ID" \
+  --installation-id "$INSTALLATION_ID" \
+  --private-key "$PRIVATE_KEY_PATH"
+```
+
+If the App lacks the metrics permission, the API returns `Resource not accessible by integration`. Add the permission to the App, then re-accept the updated permissions on the installation.
+
 ---
 
 ## Rate Limits
@@ -117,7 +138,7 @@ source ~/.config/ai-attribution/config
 | Personal Access Token | 5,000/hr | Shared across all your PAT usage |
 | GitHub App (installation token) | 15,000/hr | Dedicated to this App |
 
-A full octodemo scan (~4,100 API calls) uses **27%** of the App's hourly budget vs **82%** of a PAT's.
+The trailer scan finds closed PRs via the Search API rather than walking every repo, so it costs about two calls per closed PR. A busy day of ~500 closed PRs is roughly 1,000 calls, well within either budget.
 
 ---
 

--- a/ai-commit-attribution/scripts/ai-leverage-daily.sh
+++ b/ai-commit-attribution/scripts/ai-leverage-daily.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# ai-leverage-daily.sh
+# Daily job: calculates AI leverage and AI rejection rate for an org on GHEC.
+# Adapted from the GHES runbook for use with api.github.com.
+#
+# Usage: ./ai-leverage-daily.sh <org> [options]
+#
+# Options:
+#   --since ISO8601          Only check PRs closed after this timestamp (default: 24h ago)
+#   --app-id ID              GitHub App ID (enables App auth)
+#   --installation-id ID     GitHub App Installation ID
+#   --private-key PATH       Path to GitHub App private key (.pem)
+#
+# Auth priority:
+#   1. GitHub App (if --app-id, --installation-id, --private-key all provided)
+#   2. GH_TOKEN env var
+#   3. `gh auth token` fallback
+#
+# Output: JSON report to stdout. Progress/debug to stderr.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ORG="${1:?Usage: $0 <org> [--since ISO8601] [--app-id ID --installation-id ID --private-key PATH]}"
+shift
+
+# Parse optional flags
+SINCE=""
+APP_ID=""
+INSTALLATION_ID=""
+PRIVATE_KEY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since) SINCE="$2"; shift 2 ;;
+    --app-id) APP_ID="$2"; shift 2 ;;
+    --installation-id) INSTALLATION_ID="$2"; shift 2 ;;
+    --private-key) PRIVATE_KEY="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Default: last 24 hours
+if [[ -z "$SINCE" ]]; then
+  SINCE=$(date -u -v-1d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "1 day ago" +%Y-%m-%dT%H:%M:%SZ)
+fi
+
+# Auth setup
+if [[ -n "$APP_ID" && -n "$INSTALLATION_ID" && -n "$PRIVATE_KEY" ]]; then
+  echo "Authenticating via GitHub App (App ID: $APP_ID)..." >&2
+  TOKEN=$("$SCRIPT_DIR/generate-installation-token.sh" \
+    --app-id "$APP_ID" \
+    --installation-id "$INSTALLATION_ID" \
+    --private-key "$PRIVATE_KEY")
+  if [[ -z "$TOKEN" ]]; then
+    echo "ERROR: Failed to generate installation token." >&2
+    exit 1
+  fi
+  echo "Installation token acquired (expires in 1 hour)." >&2
+elif [[ -n "$APP_ID" || -n "$INSTALLATION_ID" || -n "$PRIVATE_KEY" ]]; then
+  echo "ERROR: GitHub App auth requires all three: --app-id, --installation-id, --private-key" >&2
+  exit 1
+else
+  TOKEN="${GH_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+  if [[ -z "$TOKEN" ]]; then
+    echo "ERROR: No GH_TOKEN env var and 'gh auth token' failed." >&2
+    echo "  Provide --app-id, --installation-id, --private-key for GitHub App auth," >&2
+    echo "  or set GH_TOKEN, or authenticate with 'gh auth login'." >&2
+    exit 1
+  fi
+fi
+
+API="https://api.github.com"
+AUTH="Authorization: token ${TOKEN}"
+ACCEPT="Accept: application/vnd.github+json"
+
+# Counters (NOT in subshells — we use process substitution to avoid pipe+while bug)
+TOTAL_MERGED=0
+TOTAL_CLOSED=0
+AI_MERGED=0
+AI_CLOSED=0
+
+echo "Scanning org: $ORG (PRs closed since $SINCE)" >&2
+
+# Check if any commit in a PR has an AI co-author trailer
+pr_has_ai() {
+  local repo="$1" pr_num="$2"
+  local messages
+  messages=$(curl -s -H "$AUTH" -H "$ACCEPT" \
+    "$API/repos/$repo/pulls/$pr_num/commits?per_page=100" | \
+    jq -r '[.[].commit.message] | join("\n")' 2>/dev/null)
+  # Match Copilot CLI, VS Code Copilot, and Claude Code trailers
+  echo "$messages" | grep -qiE "co-authored-by:.*(copilot|claude)" && return 0 || return 1
+}
+
+# Use Search API to find closed PRs directly (instead of iterating all repos).
+# This reduces ~4,100 API calls to ~10-20 for a typical daily scan.
+# Search API rate limit: 30 req/min, max 1,000 results per query.
+SINCE_DATE=$(echo "$SINCE" | cut -dT -f1)
+
+search_closed_prs() {
+  local page=1
+  while true; do
+    local body
+    body=$(curl -s -H "$AUTH" -H "$ACCEPT" \
+      "$API/search/issues?q=org:${ORG}+is:pr+is:closed+closed:>=${SINCE_DATE}&per_page=100&page=${page}")
+    local items
+    items=$(echo "$body" | jq -c '.items[]?' 2>/dev/null)
+    if [[ -z "$items" ]]; then
+      break
+    fi
+    echo "$items"
+    local count
+    count=$(echo "$body" | jq '.items | length' 2>/dev/null)
+    if [[ "$count" -lt 100 ]]; then
+      break
+    fi
+    ((page++))
+    sleep 2  # Search API: 30 req/min
+  done
+}
+
+echo "Searching for closed PRs via Search API..." >&2
+SEARCH_RESULTS=$(search_closed_prs)
+PR_COUNT=$(echo "$SEARCH_RESULTS" | grep -c '^' 2>/dev/null || echo "0")
+echo "Found $PR_COUNT closed PRs since $SINCE_DATE." >&2
+
+PR_IDX=0
+while IFS= read -r ITEM; do
+  [[ -z "$ITEM" ]] && continue
+  ((PR_IDX++))
+
+  PR_URL=$(echo "$ITEM" | jq -r '.pull_request.url // empty')
+  [[ -z "$PR_URL" ]] && continue
+
+  # Extract repo and PR number from the API URL
+  REPO=$(echo "$PR_URL" | sed 's|.*/repos/\(.*\)/pulls/.*|\1|')
+  PR_NUM=$(echo "$PR_URL" | sed 's|.*/pulls/||')
+
+  # Fetch full PR details to check merged_at (search results don't include it)
+  PR_DETAIL=$(curl -s -H "$AUTH" -H "$ACCEPT" "$PR_URL")
+  MERGED_AT=$(echo "$PR_DETAIL" | jq -r '.merged_at // "null"')
+  CLOSED_AT=$(echo "$PR_DETAIL" | jq -r '.closed_at // "null"')
+
+  # Skip if closed before our exact timestamp (search uses date granularity, not timestamp)
+  if [[ "$CLOSED_AT" < "$SINCE" ]]; then
+    continue
+  fi
+
+  if [[ "$MERGED_AT" != "null" ]]; then
+    ((TOTAL_MERGED++)) || true
+    if pr_has_ai "$REPO" "$PR_NUM"; then
+      ((AI_MERGED++)) || true
+      echo "  [$PR_IDX/$PR_COUNT] ✓ $REPO#$PR_NUM — AI-attributed MERGE" >&2
+    else
+      echo "  [$PR_IDX/$PR_COUNT]   $REPO#$PR_NUM — merged" >&2
+    fi
+  else
+    ((TOTAL_CLOSED++)) || true
+    if pr_has_ai "$REPO" "$PR_NUM"; then
+      ((AI_CLOSED++)) || true
+      echo "  [$PR_IDX/$PR_COUNT] ✗ $REPO#$PR_NUM — AI-attributed CLOSE" >&2
+    else
+      echo "  [$PR_IDX/$PR_COUNT]   $REPO#$PR_NUM — closed (no merge)" >&2
+    fi
+  fi
+  sleep 0.2
+done <<< "$SEARCH_RESULTS"
+
+echo "" >&2
+echo "Scan complete." >&2
+echo "  Merged PRs: $TOTAL_MERGED (AI: $AI_MERGED)" >&2
+echo "  Closed (no merge): $TOTAL_CLOSED (AI: $AI_CLOSED)" >&2
+
+# Calculate percentages (using awk to avoid bc dependency)
+AI_LEVERAGE=$(awk "BEGIN { if ($TOTAL_MERGED > 0) printf \"%.1f\", $AI_MERGED * 100.0 / $TOTAL_MERGED; else print \"0.0\" }")
+AI_TOTAL=$((AI_MERGED + AI_CLOSED))
+AI_REJECTION=$(awk "BEGIN { if ($AI_TOTAL > 0) printf \"%.1f\", $AI_CLOSED * 100.0 / $AI_TOTAL; else print \"0.0\" }")
+
+# Output JSON report to stdout
+cat <<EOF
+{
+  "date": "$(date -u +%Y-%m-%d)",
+  "org": "$ORG",
+  "since": "$SINCE",
+  "prs_checked": $PR_COUNT,
+  "total_merged_prs": $TOTAL_MERGED,
+  "ai_attributed_merged": $AI_MERGED,
+  "ai_leverage_pct": $AI_LEVERAGE,
+  "total_closed_without_merge": $TOTAL_CLOSED,
+  "ai_attributed_closed": $AI_CLOSED,
+  "ai_rejection_rate_pct": $AI_REJECTION
+}
+EOF

--- a/ai-commit-attribution/scripts/ai-leverage-daily.sh
+++ b/ai-commit-attribution/scripts/ai-leverage-daily.sh
@@ -81,6 +81,27 @@ TOTAL_CLOSED=0
 AI_MERGED=0
 AI_CLOSED=0
 
+# Time-to-merge accumulators (seconds), collected for median calculation
+MERGE_DURATIONS=()
+AI_MERGE_DURATIONS=()
+
+# Median of a list of integers passed as arguments. Echoes "null" if empty.
+median() {
+  local n=$#
+  if [[ "$n" -eq 0 ]]; then
+    echo "null"
+    return
+  fi
+  local sorted
+  sorted=$(printf '%s\n' "$@" | sort -n)
+  if (( n % 2 == 1 )); then
+    echo "$sorted" | awk -v idx=$(( n / 2 + 1 )) 'NR==idx { print; exit }'
+  else
+    echo "$sorted" | awk -v lo=$(( n / 2 )) -v hi=$(( n / 2 + 1 )) \
+      'NR==lo { a=$1 } NR==hi { print (a + $1) / 2; exit }'
+  fi
+}
+
 echo "Scanning org: $ORG (PRs closed since $SINCE)" >&2
 
 # Check if any commit in a PR has an AI co-author trailer
@@ -150,8 +171,16 @@ while IFS= read -r ITEM; do
 
   if [[ "$MERGED_AT" != "null" ]]; then
     ((TOTAL_MERGED++)) || true
+    # Time to merge = merged_at - created_at, in seconds. Both fields come from
+    # the standard pulls API, so this works on any GitHub edition (no Cloud API).
+    DURATION=$(echo "$PR_DETAIL" | jq -r \
+      'if .merged_at and .created_at then ((.merged_at | fromdateiso8601) - (.created_at | fromdateiso8601)) else empty end')
+    if [[ -n "$DURATION" ]]; then
+      MERGE_DURATIONS+=("$DURATION")
+    fi
     if pr_has_ai "$REPO" "$PR_NUM"; then
       ((AI_MERGED++)) || true
+      [[ -n "$DURATION" ]] && AI_MERGE_DURATIONS+=("$DURATION")
       echo "  [$PR_IDX/$PR_COUNT] ✓ $REPO#$PR_NUM — AI-attributed MERGE" >&2
     else
       echo "  [$PR_IDX/$PR_COUNT]   $REPO#$PR_NUM — merged" >&2
@@ -178,6 +207,22 @@ AI_LEVERAGE=$(awk "BEGIN { if ($TOTAL_MERGED > 0) printf \"%.1f\", $AI_MERGED * 
 AI_TOTAL=$((AI_MERGED + AI_CLOSED))
 AI_REJECTION=$(awk "BEGIN { if ($AI_TOTAL > 0) printf \"%.1f\", $AI_CLOSED * 100.0 / $AI_TOTAL; else print \"0.0\" }")
 
+# Median time-to-merge, computed client-side from PR timestamps. Convert
+# seconds to minutes (rounded to 1 decimal); emit JSON null when no data.
+MEDIAN_TTM_SEC=$(median ${MERGE_DURATIONS[@]+"${MERGE_DURATIONS[@]}"})
+MEDIAN_AI_TTM_SEC=$(median ${AI_MERGE_DURATIONS[@]+"${AI_MERGE_DURATIONS[@]}"})
+to_minutes() {
+  if [[ "$1" == "null" ]]; then
+    echo "null"
+  else
+    awk -v s="$1" 'BEGIN { printf "%.1f", s / 60.0 }'
+  fi
+}
+MEDIAN_TTM_MIN=$(to_minutes "$MEDIAN_TTM_SEC")
+MEDIAN_AI_TTM_MIN=$(to_minutes "$MEDIAN_AI_TTM_SEC")
+
+echo "  Median time-to-merge: ${MEDIAN_TTM_MIN} min (AI-attributed: ${MEDIAN_AI_TTM_MIN} min)" >&2
+
 # Output JSON report to stdout
 cat <<EOF
 {
@@ -190,6 +235,8 @@ cat <<EOF
   "ai_leverage_pct": $AI_LEVERAGE,
   "total_closed_without_merge": $TOTAL_CLOSED,
   "ai_attributed_closed": $AI_CLOSED,
-  "ai_rejection_rate_pct": $AI_REJECTION
+  "ai_rejection_rate_pct": $AI_REJECTION,
+  "median_time_to_merge_min": $MEDIAN_TTM_MIN,
+  "median_ai_time_to_merge_min": $MEDIAN_AI_TTM_MIN
 }
 EOF

--- a/ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh
+++ b/ai-commit-attribution/scripts/copilot-cloud-agent-metrics.sh
@@ -1,0 +1,213 @@
+#!/bin/bash
+# copilot-cloud-agent-metrics.sh
+# Fetches metrics for Copilot coding agent and Copilot code review from the GHEC Metrics API.
+# Use this when measuring Copilot platform features (coding agent PRs, code review).
+# For IDE completions and CLI co-authorship, use ai-leverage-daily.sh instead.
+#
+# Usage:
+#   ./scripts/copilot-cloud-agent-metrics.sh <org> [options]
+#
+# Options:
+#   --day YYYY-MM-DD         Fetch metrics for a specific day (default: yesterday)
+#   --days N                 Fetch the last N days (default: 1)
+#   --28day                  Fetch the rolling 28-day report instead
+#   --enterprise <slug>      Query enterprise-level instead of org-level
+#   --app-id ID              GitHub App ID (enables App auth)
+#   --installation-id ID     GitHub App Installation ID
+#   --private-key PATH       Path to GitHub App private key (.pem)
+#
+# Output: JSON report to stdout with PR metrics from the Copilot Metrics API.
+#
+# Required permissions: org admin or "Copilot usage metrics" access
+# Docs: https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ORG="${1:?Usage: $0 <org> [--day YYYY-MM-DD] [--days N] [--28day] [--enterprise slug]}"
+shift
+
+# Parse options
+DAY=""
+DAYS=1
+USE_28DAY=false
+ENTERPRISE=""
+APP_ID=""
+INSTALLATION_ID=""
+PRIVATE_KEY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --day) DAY="$2"; DAYS=1; shift 2 ;;
+    --days) DAYS="$2"; shift 2 ;;
+    --28day) USE_28DAY=true; shift ;;
+    --enterprise) ENTERPRISE="$2"; shift 2 ;;
+    --app-id) APP_ID="$2"; shift 2 ;;
+    --installation-id) INSTALLATION_ID="$2"; shift 2 ;;
+    --private-key) PRIVATE_KEY="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Auth setup (same pattern as ai-leverage-daily.sh)
+if [[ -n "$APP_ID" && -n "$INSTALLATION_ID" && -n "$PRIVATE_KEY" ]]; then
+  echo "Authenticating via GitHub App (App ID: $APP_ID)..." >&2
+  TOKEN=$("$SCRIPT_DIR/generate-installation-token.sh" \
+    --app-id "$APP_ID" \
+    --installation-id "$INSTALLATION_ID" \
+    --private-key "$PRIVATE_KEY")
+elif [[ -n "$APP_ID" || -n "$INSTALLATION_ID" || -n "$PRIVATE_KEY" ]]; then
+  echo "ERROR: GitHub App auth requires all three: --app-id, --installation-id, --private-key" >&2
+  exit 1
+else
+  TOKEN="${GH_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+fi
+
+if [[ -z "$TOKEN" ]]; then
+  echo "ERROR: No auth token available." >&2
+  exit 1
+fi
+
+AUTH="Authorization: token ${TOKEN}"
+ACCEPT="Accept: application/vnd.github+json"
+
+# Determine API base path
+if [[ -n "$ENTERPRISE" ]]; then
+  API_BASE="https://api.github.com/enterprises/$ENTERPRISE/copilot/metrics/reports"
+  ENTITY_LABEL="enterprise"
+  ENTITY_NAME="$ENTERPRISE"
+else
+  API_BASE="https://api.github.com/orgs/$ORG/copilot/metrics/reports"
+  ENTITY_LABEL="org"
+  ENTITY_NAME="$ORG"
+fi
+
+# Fetch NDJSON report from a download link endpoint
+fetch_ndjson() {
+  local endpoint="$1"
+  local response
+  response=$(curl -s -H "$AUTH" -H "$ACCEPT" "$endpoint")
+  local url
+  url=$(echo "$response" | jq -r '.download_links[0] // empty')
+  if [[ -z "$url" ]]; then
+    local msg
+    msg=$(echo "$response" | jq -r '.message // empty')
+    echo "ERROR: No download link from $endpoint" >&2
+    [[ -n "$msg" ]] && echo "  API said: $msg" >&2
+    echo "  Check that Copilot usage metrics are enabled for $ENTITY_NAME" >&2
+    return 1
+  fi
+  curl -s "$url"
+}
+
+if $USE_28DAY; then
+  echo "Fetching 28-day rolling report for $ENTITY_LABEL: $ENTITY_NAME..." >&2
+  if [[ -n "$ENTERPRISE" ]]; then
+    ENDPOINT="$API_BASE/enterprise-28-day/latest"
+  else
+    ENDPOINT="$API_BASE/organization-28-day/latest"
+  fi
+
+  REPORT=$(fetch_ndjson "$ENDPOINT") || exit 1
+
+  # Extract all days' PR metrics and compute aggregates
+  echo "$REPORT" | head -1 | jq --arg entity "$ENTITY_NAME" --arg entity_type "$ENTITY_LABEL" '
+    .day_totals as $days |
+    {
+      report_type: "28-day rolling",
+      ($entity_type): $entity,
+      report_start: .report_start_day,
+      report_end: .report_end_day,
+      days_with_data: ($days | length),
+
+      # Aggregate PR metrics
+      total_merged_prs: ($days | map(.pull_requests.total_merged // 0) | add),
+      total_merged_created_by_copilot: ($days | map(.pull_requests.total_merged_created_by_copilot // 0) | add),
+      total_merged_reviewed_by_copilot: ($days | map(.pull_requests.total_merged_reviewed_by_copilot // 0) | add),
+      total_prs_created: ($days | map(.pull_requests.total_created // 0) | add),
+      total_prs_created_by_copilot: ($days | map(.pull_requests.total_created_by_copilot // 0) | add),
+      total_prs_reviewed_by_copilot: ($days | map(.pull_requests.total_reviewed_by_copilot // 0) | add),
+
+      # AI leverage %
+      ai_leverage_pct: (
+        ($days | map(.pull_requests.total_merged // 0) | add) as $merged |
+        ($days | map(.pull_requests.total_merged_created_by_copilot // 0) | add) as $ai_merged |
+        if $merged > 0 then ($ai_merged * 100.0 / $merged | . * 10 | round / 10)
+        else 0 end
+      ),
+
+      # Median time to merge (average of daily medians where available)
+      median_minutes_to_merge: (
+        [$days[].pull_requests | select(.median_minutes_to_merge != null) | .median_minutes_to_merge] |
+        if length > 0 then (add / length | . * 100 | round / 100) else null end
+      ),
+      median_minutes_to_merge_copilot_authored: (
+        [$days[].pull_requests | select(.median_minutes_to_merge_copilot_authored != null) | .median_minutes_to_merge_copilot_authored] |
+        if length > 0 then (add / length | . * 100 | round / 100) else null end
+      ),
+
+      # Code review suggestions
+      total_copilot_review_suggestions: ($days | map(.pull_requests.total_copilot_suggestions // 0) | add),
+      total_copilot_applied_suggestions: ($days | map(.pull_requests.total_copilot_applied_suggestions // 0) | add),
+
+      # Activity
+      avg_daily_active_users: ($days | map(.daily_active_users // 0) | add / length | round)
+    }'
+
+else
+  # Single-day or multi-day mode
+  if [[ -z "$DAY" ]]; then
+    DAY=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "1 day ago" +%Y-%m-%d)
+  fi
+
+  echo "Fetching daily report(s) for $ENTITY_LABEL: $ENTITY_NAME (starting $DAY, $DAYS day(s))..." >&2
+
+  RESULTS="["
+  SEP=""
+  for ((i = 0; i < DAYS; i++)); do
+    QUERY_DAY=$(date -u -v-${i}d -j -f "%Y-%m-%d" "$DAY" +%Y-%m-%d 2>/dev/null || \
+                date -u -d "$DAY - $i days" +%Y-%m-%d)
+
+    if [[ -n "$ENTERPRISE" ]]; then
+      ENDPOINT="$API_BASE/enterprise-1-day?day=$QUERY_DAY"
+    else
+      ENDPOINT="$API_BASE/organization-1-day?day=$QUERY_DAY"
+    fi
+
+    REPORT=$(fetch_ndjson "$ENDPOINT" 2>/dev/null) || { echo "  Skipping $QUERY_DAY (no data)" >&2; continue; }
+
+    DAY_DATA=$(echo "$REPORT" | head -1 | jq --arg day "$QUERY_DAY" '{
+      day: $day,
+      daily_active_users: (.daily_active_users // 0),
+      pull_requests: {
+        total_merged: (.pull_requests.total_merged // 0),
+        total_merged_created_by_copilot: (.pull_requests.total_merged_created_by_copilot // 0),
+        total_merged_reviewed_by_copilot: (.pull_requests.total_merged_reviewed_by_copilot // 0),
+        total_created: (.pull_requests.total_created // 0),
+        total_created_by_copilot: (.pull_requests.total_created_by_copilot // 0),
+        total_reviewed_by_copilot: (.pull_requests.total_reviewed_by_copilot // 0),
+        median_minutes_to_merge: (.pull_requests.median_minutes_to_merge // null),
+        median_minutes_to_merge_copilot_authored: (.pull_requests.median_minutes_to_merge_copilot_authored // null),
+        total_copilot_suggestions: (.pull_requests.total_copilot_suggestions // 0),
+        total_copilot_applied_suggestions: (.pull_requests.total_copilot_applied_suggestions // 0),
+        ai_leverage_pct: (
+          if (.pull_requests.total_merged // 0) > 0
+          then ((.pull_requests.total_merged_created_by_copilot // 0) * 100.0 / .pull_requests.total_merged | . * 10 | round / 10)
+          else 0 end
+        )
+      }
+    }')
+
+    RESULTS="${RESULTS}${SEP}${DAY_DATA}"
+    SEP=","
+    echo "  $QUERY_DAY — fetched" >&2
+  done
+  RESULTS="${RESULTS}]"
+
+  echo "$RESULTS" | jq --arg entity "$ENTITY_NAME" --arg entity_type "$ENTITY_LABEL" '{
+    report_type: "daily",
+    ($entity_type): $entity,
+    days: .
+  }'
+fi

--- a/ai-commit-attribution/scripts/generate-installation-token.sh
+++ b/ai-commit-attribution/scripts/generate-installation-token.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# generate-installation-token.sh
+# Generates a GitHub App installation token from a private key.
+# Uses only openssl (pre-installed on macOS/Linux) — no extra dependencies.
+#
+# Usage:
+#   ./generate-installation-token.sh --app-id 12345 --installation-id 67890 --private-key path/to/key.pem
+#
+# Output: Installation token to stdout (use as GH_TOKEN)
+
+set -euo pipefail
+
+# Parse arguments
+APP_ID=""
+INSTALLATION_ID=""
+PRIVATE_KEY_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app-id) APP_ID="$2"; shift 2 ;;
+    --installation-id) INSTALLATION_ID="$2"; shift 2 ;;
+    --private-key) PRIVATE_KEY_PATH="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; echo "Usage: $0 --app-id ID --installation-id ID --private-key PATH" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$APP_ID" || -z "$INSTALLATION_ID" || -z "$PRIVATE_KEY_PATH" ]]; then
+  echo "ERROR: --app-id, --installation-id, and --private-key are all required." >&2
+  exit 1
+fi
+
+if [[ ! -f "$PRIVATE_KEY_PATH" ]]; then
+  echo "ERROR: Private key not found: $PRIVATE_KEY_PATH" >&2
+  exit 1
+fi
+
+# --- Generate JWT ---
+# GitHub App JWTs are RS256-signed, valid for max 10 minutes.
+# We set iat to 60s ago (clock skew) and exp to 10 minutes from now.
+
+NOW=$(date +%s)
+IAT=$((NOW - 60))
+EXP=$((NOW + 600))
+
+# Base64url encode (no padding, URL-safe)
+b64url() {
+  openssl base64 -e -A | tr '+/' '-_' | tr -d '='
+}
+
+# JWT Header
+HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+
+# JWT Payload
+PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$IAT" "$EXP" "$APP_ID" | b64url)
+
+# Sign
+SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | \
+  openssl dgst -sha256 -sign "$PRIVATE_KEY_PATH" -binary | b64url)
+
+JWT="${HEADER}.${PAYLOAD}.${SIGNATURE}"
+
+# --- Exchange JWT for Installation Token ---
+RESPONSE=$(curl -s -X POST \
+  -H "Authorization: Bearer $JWT" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/app/installations/$INSTALLATION_ID/access_tokens")
+
+TOKEN=$(echo "$RESPONSE" | jq -r '.token // empty')
+
+if [[ -z "$TOKEN" ]]; then
+  echo "ERROR: Failed to get installation token." >&2
+  echo "Response: $RESPONSE" >&2
+  exit 1
+fi
+
+echo "$TOKEN"

--- a/ai-commit-attribution/scripts/generate-installation-token.sh
+++ b/ai-commit-attribution/scripts/generate-installation-token.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # generate-installation-token.sh
 # Generates a GitHub App installation token from a private key.
-# Uses only openssl (pre-installed on macOS/Linux) — no extra dependencies.
+# Requires: openssl, curl, jq (all pre-installed or easily available on macOS/Linux).
 #
 # Usage:
 #   ./generate-installation-token.sh --app-id 12345 --installation-id 67890 --private-key path/to/key.pem

--- a/copilot-otel-intune.md
+++ b/copilot-otel-intune.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Copilot OpenTelemetry via Intune
+description: Centrally deploy OpenTelemetry monitoring for Copilot across Windows and macOS using Microsoft Intune
 toc: true
 ---
 
@@ -8,8 +9,6 @@ toc: true
 {:.no_toc}
 
 *Last updated: June 19, 2026*
-
-How to centrally manage OpenTelemetry (OTel) monitoring for GitHub Copilot across a fleet of developer machines — both **VS Code Copilot agents** and the **standalone Copilot CLI** — using **Microsoft Intune** on Windows and macOS.
 
 ---
 

--- a/copilot-otel-intune.md
+++ b/copilot-otel-intune.md
@@ -1,0 +1,206 @@
+---
+layout: default
+title: Copilot OpenTelemetry via Intune
+toc: true
+---
+
+# Copilot OpenTelemetry via Intune
+{:.no_toc}
+
+*Last updated: June 19, 2026*
+
+How to centrally manage OpenTelemetry (OTel) monitoring for GitHub Copilot across a fleet of developer machines — both **VS Code Copilot agents** and the **standalone Copilot CLI** — using **Microsoft Intune** on Windows and macOS.
+
+---
+
+## Key constraint (read first)
+
+OTel agent monitoring is **NOT** an enforceable VS Code enterprise policy. The VS Code policy allowlist (`/docs/enterprise/policies`) does **not** include any `github.copilot.chat.otel.*` setting. So you cannot *lock* OTel on the endpoint — you can only push it as an **overridable default** via environment variables or a default `settings.json`. A determined developer can override it.
+
+- **Fine for observability** (honest developers, fleet usage/cost dashboards) → pair with drift remediation (Part 1C).
+- **Not sufficient for compliance/audit** → anchor on GitHub's server-side audit log + Copilot metrics API, gate usage with the `ChatApprovedAccountOrganizations` policy, and for hard guarantees push work into org-controlled runtimes (Codespaces/VDI). Endpoint OTel is enrichment only.
+
+## Reference docs
+
+- [VS Code agent OTel monitoring](https://code.visualstudio.com/docs/agents/guides/monitoring-agents)
+- [VS Code enterprise policies (allowlist)](https://code.visualstudio.com/docs/enterprise/policies)
+- [VS Code enterprise AI settings](https://code.visualstudio.com/docs/enterprise/ai-settings)
+- [Copilot CLI command reference (OTel monitoring)](https://docs.github.com/en/enterprise-cloud@latest/copilot/reference/copilot-cli-reference/cli-command-reference#opentelemetry-monitoring)
+
+---
+
+## Architecture overview
+
+- **One target endpoint:** your org's OTLP/HTTP collector, e.g. `https://otel-collector.corp.example.com:4318`.
+- **Two device platforms**, each with its own Intune mechanism.
+- **Two app surfaces** per device: VS Code (GUI) agent + standalone `copilot` CLI (terminal).
+- **Recommended split:**
+  - **Windows** → push **machine-level environment variables** (covers VS Code *and* CLI in one shot — Windows GUI apps inherit machine env vars cleanly).
+  - **macOS** → push a **default `settings.json`** for the VS Code half (avoids the GUI-launchd headache) **plus** an env-var file for the CLI half.
+- **Content capture stays OFF** everywhere (metadata only — no prompts/code).
+- **Standardize on `otlp-http`** — the standalone CLI only supports HTTP.
+
+### Shared OTel variables / settings
+
+| Env var | settings.json equivalent | Value |
+|---|---|---|
+| `COPILOT_OTEL_ENABLED` | `github.copilot.chat.otel.enabled` | `true` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `github.copilot.chat.otel.otlpEndpoint` | collector URL |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `github.copilot.chat.otel.exporterType` (`otlp-http`) | `http/protobuf` |
+| `OTEL_RESOURCE_ATTRIBUTES` | (resource attrs) | `team.id=...,department=...` |
+| `COPILOT_OTEL_CAPTURE_CONTENT` | `github.copilot.chat.otel.captureContent` | `false` |
+
+> [!IMPORTANT]
+> Environment variables always take precedence over VS Code settings.
+
+---
+
+## Part 1 — Windows via Intune
+
+### 1A. Machine-level env vars (Custom OMA-URI)
+
+Windows stores machine env vars in the registry under
+`HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`.
+
+**Intune → Devices → Configuration → Create → Windows 10 and later → Templates → Custom.**
+Add each as Data type **String**:
+
+| Name | OMA-URI | Value |
+|---|---|---|
+| OTel Enabled | `./Device/Vendor/MSFT/Registry/HKLM/SYSTEM/CurrentControlSet/Control/Session Manager/Environment/COPILOT_OTEL_ENABLED` | `true` |
+| OTel Endpoint | `./Device/Vendor/MSFT/Registry/HKLM/SYSTEM/CurrentControlSet/Control/Session Manager/Environment/OTEL_EXPORTER_OTLP_ENDPOINT` | `https://otel-collector.corp.example.com:4318` |
+| OTel Protocol | `./Device/Vendor/MSFT/Registry/HKLM/SYSTEM/CurrentControlSet/Control/Session Manager/Environment/OTEL_EXPORTER_OTLP_PROTOCOL` | `http/protobuf` |
+| Resource Attrs | `./Device/Vendor/MSFT/Registry/HKLM/SYSTEM/CurrentControlSet/Control/Session Manager/Environment/OTEL_RESOURCE_ATTRIBUTES` | `team.id=platform,department=engineering` |
+
+Assign to a device group. A reboot/next logon makes them live; new VS Code / `copilot` processes inherit them.
+
+### 1B. PowerShell platform script (alternative to 1A)
+
+**Intune → Devices → Scripts and remediations → Platform scripts → Add → Windows 10 and later.** Run in **system context**, 64-bit.
+
+```powershell
+# Set-CopilotOtelEnv.ps1
+$vars = @{
+  'COPILOT_OTEL_ENABLED'         = 'true'
+  'OTEL_EXPORTER_OTLP_ENDPOINT'  = 'https://otel-collector.corp.example.com:4318'
+  'OTEL_EXPORTER_OTLP_PROTOCOL'  = 'http/protobuf'
+  'OTEL_RESOURCE_ATTRIBUTES'     = 'team.id=platform,department=engineering'
+}
+foreach ($k in $vars.Keys) {
+  [System.Environment]::SetEnvironmentVariable($k, $vars[$k], 'Machine')
+}
+```
+
+### 1C. Proactive Remediation for drift control (recommended)
+
+**Intune → Devices → Scripts and remediations → Remediations → Create** (requires Intune Premium / qualifying license). Schedule daily.
+
+**Detection** (exit 1 = needs fix):
+
+```powershell
+$want = 'https://otel-collector.corp.example.com:4318'
+$have = [System.Environment]::GetEnvironmentVariable('OTEL_EXPORTER_OTLP_ENDPOINT','Machine')
+if ($have -ne $want) { Write-Output "drift: $have"; exit 1 }
+$en = [System.Environment]::GetEnvironmentVariable('COPILOT_OTEL_ENABLED','Machine')
+if ($en -ne 'true') { Write-Output "disabled"; exit 1 }
+exit 0
+```
+
+**Remediation** = the body of 1B.
+
+---
+
+## Part 2 — macOS via Intune
+
+macOS has **no native env-var payload**, and GUI VS Code ignores shell profiles. Split the two surfaces.
+
+### 2A. VS Code half → default `settings.json` (shell script)
+
+**Intune → Devices → Scripts → add a shell script** (macOS). Run as **root**, e.g. daily (re-runs give drift correction).
+
+```bash
+#!/bin/bash
+# deploy-vscode-otel-settings.sh
+# Writes a default Copilot OTel config into each local user's VS Code settings.
+# Note: this is a DEFAULT a user can still edit; that's expected.
+
+ENDPOINT="https://otel-collector.corp.example.com:4318"
+
+for HOME_DIR in /Users/*; do
+  USER_NAME=$(basename "$HOME_DIR")
+  [ "$USER_NAME" = "Shared" ] && continue
+  SETTINGS_DIR="$HOME_DIR/Library/Application Support/Code/User"
+  SETTINGS="$SETTINGS_DIR/settings.json"
+  [ -d "$HOME_DIR/Library/Application Support/Code" ] || continue
+  mkdir -p "$SETTINGS_DIR"
+
+  if command -v jq >/dev/null 2>&1 && [ -f "$SETTINGS" ]; then
+    tmp=$(mktemp)
+    jq --arg ep "$ENDPOINT" '
+      ."github.copilot.chat.otel.enabled" = true
+      | ."github.copilot.chat.otel.exporterType" = "otlp-http"
+      | ."github.copilot.chat.otel.otlpEndpoint" = $ep
+      | ."github.copilot.chat.otel.captureContent" = false
+    ' "$SETTINGS" > "$tmp" && mv "$tmp" "$SETTINGS"
+  else
+    cat > "$SETTINGS" <<EOF
+{
+  "github.copilot.chat.otel.enabled": true,
+  "github.copilot.chat.otel.exporterType": "otlp-http",
+  "github.copilot.chat.otel.otlpEndpoint": "$ENDPOINT",
+  "github.copilot.chat.otel.captureContent": false
+}
+EOF
+  fi
+  chown "$USER_NAME" "$SETTINGS"
+done
+```
+
+> [!NOTE]
+> The `jq` merge preserves other settings; the fallback overwrites. Deploy `jq` first if you can't guarantee it.
+
+### 2B. CLI half → managed shell env file (shell script)
+
+Same Intune shell-script vehicle. Writes `/etc/zshenv` (read by all zsh sessions — default shell on modern macOS):
+
+```bash
+#!/bin/bash
+# deploy-cli-otel-env.sh
+cat > /etc/zshenv <<'EOF'
+export COPILOT_OTEL_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-collector.corp.example.com:4318
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_RESOURCE_ATTRIBUTES=team.id=platform,department=engineering
+EOF
+chmod 644 /etc/zshenv
+```
+
+> [!NOTE]
+> For bash users, also append the same `export` lines to `/etc/profile`. To cover GUI-launched VS Code with env vars instead of 2A's settings.json, deploy a LaunchAgent calling `launchctl setenv` — but the settings.json route in 2A is cleaner and preferred.
+
+---
+
+## Part 3 — Cross-platform notes
+
+- **Protocol:** keep everything on `otlp-http` / port `4318`. The standalone CLI terminal sessions only speak HTTP; if you set gRPC for VS Code, the CLI silently falls back. Standardize on HTTP (or use a collector like Aspire that serves both on one port).
+- **Service names in your backend:**
+  - `copilot-chat` → VS Code foreground agent + in-editor CLI wrapper + Claude agent spans.
+  - `github-copilot` → CLI SDK native spans + standalone terminal CLI sessions.
+- **Content capture:** left `false` everywhere. Only enable with legal/privacy sign-off — it captures prompts, code, file contents, and tool args.
+- **Auth to the collector:** if needed, add `OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer <token>` the same way — but treat the token as a secret. Intune script/registry values aren't a secret store, so prefer mTLS or network-level trust over a plaintext bearer token.
+
+---
+
+## Part 4 — Verification
+
+1. **Windows:** after policy sync + reboot, `cmd` → `set OTEL` lists the vars. Launch VS Code, run an agent turn → spans under `copilot-chat`. Run `copilot` in a terminal → `github-copilot` spans.
+2. **macOS:** VS Code **Settings → search `copilot otel`** → values show your endpoint. Terminal: `echo $OTEL_EXPORTER_OTLP_ENDPOINT`. Generate traffic in both → both service names appear.
+3. **Backend:** confirm `gen_ai.usage.input_tokens` / `output_tokens`, model names, and your `team.id` resource attribute for segmentation.
+4. **Drift:** remove a var on a test box, wait for the next remediation/script cycle, confirm re-application.
+
+---
+
+## Before shipping
+
+- Swap in the real collector hostname/port and your actual `team.id` / `department` tagging scheme.
+- Decide the macOS VS Code path — default `settings.json` (2A) is the cleaner option; the LaunchAgent env-var alternative is the fallback.

--- a/cost-management.md
+++ b/cost-management.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Managing Copilot usage-based billing
+description: AI Credits, budget controls, and strategies for predictable spending under GitHub's Usage-Based Billing model
 toc: true
 ---
 
@@ -8,8 +9,6 @@ toc: true
 {:.no_toc}
 
 *Last updated: June 12, 2026*
-
-GitHub Copilot usage-based billing (UBB) uses a shared pool of AI Credits (AICs) where all licensed users draw from a central enterprise pool. When the pool runs out, metered billing kicks in, and layered budgets control what happens next.
 
 ## Key resources
 

--- a/cost-management.md
+++ b/cost-management.md
@@ -8,7 +8,7 @@ toc: true
 # Managing Copilot usage-based billing
 {:.no_toc}
 
-*Last updated: June 12, 2026*
+*Last updated: June 19, 2026*
 
 ## Key resources
 

--- a/cost-management.md
+++ b/cost-management.md
@@ -263,9 +263,10 @@ Publish a simple end-of-month summary ("Pool was 74% consumed, no one was blocke
 Budgets control how much each user *can* spend — but the most effective cost lever is making every credit count. Well-scoped agent sessions, deliberate model selection, and deterministic guardrails (tests, linters, security scans) all reduce retries and wasted tokens, which directly lowers credit consumption without limiting developer productivity.
 
 Key resources for developers:
-
+**GitHub Docs**
+- **Optimize AI usage** — GitHub's official five strategies for higher-quality agents that complete tasks in fewer attempts: model selection, prompt guidance, the research-plan-implement workflow, deterministic guardrails, and concise `copilot-instructions.md` files: [Optimize AI usage](https://docs.github.com/en/enterprise-cloud@latest/copilot/tutorials/optimize-ai-usage)
+**Field Maintained Information**
 - **Interactive token optimization guide** — Scenarios, a cost calculator, a model-selection playbook, and copy-paste templates: [GitHub Copilot Token Optimizer](https://ashy-dune-0b4215a0f.7.azurestaticapps.net/index.html)
-- **Optimize AI usage** — GitHub's five strategies for higher-quality agents that complete tasks in fewer attempts: model selection, prompt guidance, the research-plan-implement workflow, deterministic guardrails, and concise `copilot-instructions.md` files: [Optimize AI usage](https://docs.github.com/en/enterprise-cloud@latest/copilot/tutorials/optimize-ai-usage)
 
 > [!TIP]
 > Teams that invest in agent quality guardrails often see **fewer retries and lower total token spend** — even when individual steps use slightly more tokens upfront. Pair this with the budget strategy above: when power users hit their limits less often, you spend less time adjusting budgets and more time shipping. For developers who want hands-on practice, share the [Context Engineering Lab](https://copilot-academy.github.io/labs/context-engineering-lab) — a 2-hour workshop on measuring and reducing token consumption.
@@ -298,6 +299,3 @@ When someone reports being blocked, work through these checks in order:
 > [!NOTE]
 > A common misconception is that placing a user in a Cost Center with a higher budget will let them exceed their Universal User Budget. It won't. Cost Center budgets track overage spend, not pooled entitlement usage. The only way to give a user more headroom within the pool is to raise their Universal User Budget or assign an Individual User Budget.
 
----
-
-*Budget guidance adapted from [xrvk](https://github.com/xrvk)*

--- a/index.md
+++ b/index.md
@@ -27,4 +27,6 @@ The highest-impact adoption strategies focus on raising the floor across your or
 The following pages cover topics not yet addressed by official documentation and remain actively maintained.
 
 - [Strategies for Managing Copilot Usage-Based Billing](./cost-management) — Practical guide to AI Credits, budget controls, and strategies for predictable spending under GitHub's Usage-Based Billing model
-- [GitHub Copilot Token Optimizer](https://ashy-dune-0b4215a0f.7.azurestaticapps.net/index.html) — Interactive guide to token optimization with context rot scenarios, a cost calculator, a model-selection playbook, and copy-paste templates for reducing token consumption
+- [AI Commit Attribution — GHES Runbook](./ai-commit-attribution) — How to track AI-authored commits on GitHub Enterprise Server using co-author trailers, VS Code settings, git hooks, and the GHES REST API
+- [Copilot OpenTelemetry via Intune](./copilot-otel-intune) — Centrally deploy OpenTelemetry monitoring for Copilot (VS Code agents + CLI) across Windows and macOS using Microsoft Intune
+

--- a/index.md
+++ b/index.md
@@ -27,6 +27,6 @@ The highest-impact adoption strategies focus on raising the floor across your or
 The following pages cover topics not yet addressed by official documentation and remain actively maintained.
 
 - [Strategies for Managing Copilot Usage-Based Billing](./cost-management) — Practical guide to AI Credits, budget controls, and strategies for predictable spending under GitHub's Usage-Based Billing model
-- [AI Commit Attribution — GHES Runbook](./ai-commit-attribution) — How to track AI-authored commits on GitHub Enterprise Server using co-author trailers, VS Code settings, git hooks, and the GHES REST API
+- [Measuring AI in Pull Requests](./ai-commit-attribution) — Stop counting lines of code. Measure AI's contribution to merged PRs with two example scripts: trailer scanning for IDE and CLI usage, and the Copilot usage metrics API for coding agent and code review.
 - [Copilot OpenTelemetry via Intune](./copilot-otel-intune) — Centrally deploy OpenTelemetry monitoring for Copilot (VS Code agents + CLI) across Windows and macOS using Microsoft Intune
 

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: GitHub Copilot Adoption Resources
+description: Guides for cost management, AI commit attribution, and OpenTelemetry monitoring — plus curated links to official Copilot rollout documentation
 ---
 
 > [!NOTE]
@@ -26,7 +27,7 @@ The highest-impact adoption strategies focus on raising the floor across your or
 
 The following pages cover topics not yet addressed by official documentation and remain actively maintained.
 
-- [Strategies for Managing Copilot Usage-Based Billing](./cost-management) — Practical guide to AI Credits, budget controls, and strategies for predictable spending under GitHub's Usage-Based Billing model
-- [Measuring AI in Pull Requests](./ai-commit-attribution) — Stop counting lines of code. Measure AI's contribution to merged PRs with two example scripts: trailer scanning for IDE and CLI usage, and the Copilot usage metrics API for coding agent and code review.
-- [Copilot OpenTelemetry via Intune](./copilot-otel-intune) — Centrally deploy OpenTelemetry monitoring for Copilot (VS Code agents + CLI) across Windows and macOS using Microsoft Intune
+- [Managing Copilot Usage-Based Billing](./cost-management)
+- [Measuring AI in Pull Requests](./ai-commit-attribution)
+- [Copilot OpenTelemetry via Intune](./copilot-otel-intune)
 


### PR DESCRIPTION
## Summary

This PR updates the AI commit attribution documentation and example script to reflect the current support matrix more accurately.

### What changed
- Corrected the claim that Cursor and Windsurf have no attribution support:
  - Cursor agent commits now documented as carrying a default `Made with Cursor` trailer (not `Co-authored-by` format)
  - Windsurf remains documented as not adding any detectable attribution trailer
- Updated the docs to explain that time-to-merge can be computed from standard PR timestamps without using the Cloud-only Copilot metrics API
- Expanded the example script to compute median time-to-merge from each PR's `created_at`/`merged_at` values and expose those metrics in the JSON output
- Updated the related README and GHES-vs-Cloud comparison docs to reflect the new behavior and clarify the difference between trailer-based metrics and Cloud-only metrics API data

## Testing

- Verified the updated script syntax with `bash -n`
- Verified the new median/time-to-merge logic and JSON output shape in a local shell test
