### PR TITLE
Add Copilot metrics and billing collection guide

### DIFF
--- a/copilot-metrics-billing.md
+++ b/copilot-metrics-billing.md
@@ -1,0 +1,233 @@
+---
+layout: default
+title: Pulling Copilot Metrics & Billing Into Your Data Lake
+description: How Copilot admins set up the credentials and APIs to pull usage metrics and billing data daily into their own data lake, with minimal API calls
+toc: true
+---
+
+# Pulling Copilot Metrics & Billing Into Your Data Lake
+{:.no_toc}
+
+*Last updated: June 22, 2026*
+
+---
+
+## What it takes
+
+GitHub only retains Copilot usage metrics for about 28 days, so if you want a
+longer adoption history (or billing data for chargeback) you have to pull it
+yourself and keep your own copy. The whole job:
+
+1. **Set up two credentials** (they can't be shared):
+   - an **Enterprise GitHub App** for **usage metrics**, and
+   - a **billing-manager classic PAT** for **billing data**.
+2. **Run two pulls once a day** against the prior complete day, each using the
+   **pre-aggregated report** endpoints so the whole thing is under ten API calls.
+3. **Drop the files into your data lake** before the 28-day window rolls off.
+
+The [example scripts](./copilot-metrics-billing/README.md) do exactly this. The
+rest of this page explains the model so you can adapt it.
+
+> [!NOTE]
+> This applies to GitHub Enterprise Cloud (including EMU). The endpoints are
+> enterprise-scoped against `api.github.com`.
+
+---
+
+## Two domains, don't confuse them
+
+| | **Usage metrics** | **Billing metrics** |
+|---|---|---|
+| What it is | Engagement/adoption — active users, completions, chat | Consumption/cost — AI Credits, quantities, dollar amounts |
+| Endpoint family | `/enterprises/{ent}/copilot/metrics/reports/...` | `/enterprises/{ent}/settings/billing/reports` |
+| Dollar amounts | ❌ none | ✅ yes |
+| Auth | Enterprise GitHub App *(or PAT `read:enterprise`)* | Classic PAT `manage_billing:enterprise` |
+
+Usage metrics tell you *who is using Copilot and how much*. Billing tells you
+*what it costs*. They come from different APIs with different auth, so you collect
+them separately and join them later in your warehouse (on `username` / `date`).
+
+---
+
+## Why two credentials
+
+This trips people up, so it's worth stating plainly: **GitHub Apps and
+fine-grained PATs cannot read billing endpoints.** Billing requires a **classic
+PAT with `manage_billing:enterprise`**, held by an enterprise owner or billing
+manager which is assigned by IDP.
+
+Usage metrics, by contrast, work well with an **Enterprise GitHub App**. You get
+a 15,000 req/hr limit and short-lived (1-hour) installation tokens instead of a
+long-lived PAT.
+
+| | Usage metrics | Billing |
+|---|---|---|
+| Enterprise GitHub App | ✅ *View Enterprise Copilot Metrics* | ❌ not supported |
+| Fine-grained PAT | ⚠️ documented, not yet in the UI | ❌ not supported |
+| Classic PAT scope | `read:enterprise` or `manage_billing:copilot` | `manage_billing:enterprise` |
+
+See [enterprise-setup.md](./copilot-metrics-billing/enterprise-setup.md) for the
+one-time setup of both.
+
+---
+
+## Minimizing API calls
+
+These endpoints do the aggregation for you. Use the
+**report** endpoints, not per-user or per-day loops:
+
+- **Usage metrics:** one request returns a signed `download_links` URL to an
+  NDJSON file with the whole day's aggregated metrics. Download it. **~2 calls.**
+- **Billing:** the **bulk CSV export** returns *every* user, day, and model in a
+  single file via create → poll → download. **~3–5 calls.** This is far cheaper
+  than calling `/ai_credit/usage?user=X` once per user, and it's the *only* way
+  to get per-user fields (`username`, `total_monthly_quota`, `cost_center_name`)
+  without already knowing every username.
+
+A full daily collection is **under ten API calls**. Run it once a day against the
+prior complete UTC day and you'll never come close to a rate limit.
+
+> [!IMPORTANT]
+> Don't use the legacy `GET /enterprises/{ent}/copilot/metrics` endpoint. It was
+> closed April 2, 2026 and returns 404. Use the
+> `/copilot/metrics/reports/enterprise-1-day` report endpoint instead.
+
+---
+
+## The endpoints
+
+### Usage metrics (engagement)
+
+Call **one** report endpoint per run. Enterprise-level is the primary target; use
+the org-level row only if you need per-org breakdowns or you only have org
+access. Each returns `download_links` to an NDJSON report you then download.
+
+| What you want | Endpoint to call | Docs |
+|---|---|---|
+| Enterprise, single day | `GET /enterprises/{ent}/copilot/metrics/reports/enterprise-1-day?day=YYYY-MM-DD` | [Enterprise, specific day](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics#get-copilot-enterprise-usage-metrics-for-a-specific-day) |
+| Org, single day | `GET /orgs/{org}/copilot/metrics/reports/organization-1-day?day=YYYY-MM-DD` | [Org, specific day](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics#get-copilot-organization-usage-metrics-for-a-specific-day) |
+
+Pull the **single-day** report each day. There are also 28-day rolling report
+endpoints, but you don't need them here: once you're archiving the daily files,
+you reconstruct any window (7, 28, 90 days) from your own data instead of asking
+GitHub to re-roll it.
+
+Requires the **Copilot usage metrics** policy to be **Enabled everywhere**.
+GitHub only retains this data for about 28 days, so pull it daily and archive it
+yourself. Reference page:
+[REST API endpoints for Copilot usage metrics](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics).
+
+### Billing (cost)
+
+Three calls, in order. The CSV export is the only way to get per-user rows
+without one call per known username.
+
+| Step | Endpoint to call | Docs |
+|---|---|---|
+| 1. Create the report | `POST /enterprises/{ent}/settings/billing/reports` — body `{"report_type":"ai_credit","start_date":"YYYY-MM-DD","end_date":"YYYY-MM-DD"}` (returns `202` + a report `id`) | [Create a usage report export](https://docs.github.com/en/enterprise-cloud@latest/rest/billing/usage-reports?apiVersion=2026-03-10#create-a-usage-report-export) |
+| 2. Poll until `status: completed` | `GET /enterprises/{ent}/settings/billing/reports/{id}` | [Get a usage report export](https://docs.github.com/en/enterprise-cloud@latest/rest/billing/usage-reports?apiVersion=2026-03-10#get-a-usage-report-export) |
+| 3. Download the CSV | fetch the signed `download_urls[0]` from step 2 (expires ~1h) | — |
+
+Send header `X-GitHub-Api-Version: 2026-03-10` on all three. Billing data is
+available for the past 24 months. Reference page:
+[REST API endpoints for usage reports](https://docs.github.com/en/enterprise-cloud@latest/rest/billing/usage-reports?apiVersion=2026-03-10).
+
+The `ai_credit` CSV gives you per-user, per-day, per-model rows with dollar
+amounts:
+
+```
+date, username, product, sku, model, quantity, unit_type,
+applied_cost_per_quantity, gross_amount, discount_amount, net_amount,
+total_monthly_quota, organization, repository, cost_center_name,
+aic_quantity, aic_gross_amount
+```
+
+> [!TIP]
+> For a fast "total Copilot spend this month" number without the export, call
+> `GET /enterprises/{ent}/settings/billing/usage/summary?product=Copilot`
+> ([docs](https://docs.github.com/en/enterprise-cloud@latest/rest/billing/usage?apiVersion=2026-03-10#get-billing-usage-summary-for-an-enterprise)).
+> One call, aggregated totals, but no per-user breakdown.
+
+---
+
+## The scripts
+
+The [`copilot-metrics-billing/`](./copilot-metrics-billing/README.md) folder ships
+example scripts that implement the above. They're a starting point: clean stdout
+(JSON/CSV), progress to stderr, meant to be adapted into your pipeline.
+
+| Script | What it does |
+|--------|--------------|
+| `copilot-usage-metrics.sh` | Pulls the enterprise (or `--org`) daily usage report → JSON. App or PAT auth. |
+| `copilot-billing-export.sh` | Creates, polls, and downloads the `ai_credit` billing CSV. Classic PAT auth. |
+| `collect-daily.sh` | Runs both for the prior day and writes timestamped files to an output dir. |
+| `generate-installation-token.sh` | Mints the short-lived App token (used internally by the usage script). |
+
+```bash
+source ~/.config/copilot-metrics/config   # APP_ID, INSTALLATION_ID, PRIVATE_KEY
+export GH_BILLING_TOKEN=ghp_xxx            # classic PAT, manage_billing:enterprise
+
+./copilot-metrics-billing/scripts/collect-daily.sh my-enterprise \
+  --out-dir ./copilot-data \
+  --app-id "$APP_ID" --installation-id "$INSTALLATION_ID" --private-key "$PRIVATE_KEY"
+```
+
+Output:
+
+```
+copilot-data/usage-enterprise-my-enterprise-2026-06-21.json
+copilot-data/billing-ai_credit-my-enterprise-2026-06-21.csv
+```
+
+See the [scripts README](./copilot-metrics-billing/README.md) for full options
+and output schemas.
+
+---
+
+## Running it daily and landing it in a data lake
+
+Schedule `collect-daily.sh` once a day. A GitHub Actions cron, a Jenkins job, a
+GitLab schedule, or a plain `cron` entry all work. It writes timestamped files to
+an output directory; from there, sync that directory to object storage with
+whatever you already use:
+
+```bash
+# pick the one that matches your stack
+aws s3 cp ./copilot-data s3://my-bucket/copilot/$(date -u +%F)/ --recursive   # AWS S3
+az storage blob upload-batch -d copilot/$(date -u +%F) -s ./copilot-data       # Azure Blob
+gcloud storage cp ./copilot-data/* gs://my-bucket/copilot/$(date -u +%F)/      # GCS
+```
+
+Once the JSON and CSV are in your lake, load them into your warehouse and join on
+`username` and `date` to put adoption next to cost. The shape of that warehouse
+is your call. Partition the raw files by date and your daily pull becomes an
+append-only history you can rebuild dashboards from at any time.
+
+> [!NOTE]
+> Keep the raw files. GitHub only retains usage metrics for ~28 days (billing for
+> 24 months), so your archived daily pulls become the long-term record. For usage
+> metrics, they're the *only* record once you're past the 28-day window.
+
+---
+
+## Gotchas
+
+- **One billing report at a time per enterprise.** A second `POST .../reports`
+  while one is running returns `409`. The daily cadence avoids this.
+- **Download URLs expire in ~1 hour.** Fetch the file immediately (the scripts
+  do).
+- **Single-enterprise scope.** Each call targets one enterprise, so
+  multi-enterprise customers run the collection once per enterprise.
+- **Usage-metrics policy must be on.** Without **Copilot usage metrics → Enabled
+  everywhere**, the report endpoints return no data.
+- **Run against the prior complete day.** "Today" isn't fully processed yet;
+  default to yesterday (UTC).
+
+---
+
+## Related
+
+- [Managing Copilot usage-based billing](./cost-management) — budgets, AI Credits,
+  and keeping spend predictable.
+- [Measuring AI in Pull Requests](./ai-commit-attribution) — AI leverage from
+  commit trailers and the Copilot usage metrics API.

--- a/copilot-metrics-billing/README.md
+++ b/copilot-metrics-billing/README.md
@@ -1,0 +1,183 @@
+# Copilot Metrics & Billing — Scripts
+
+Self-contained example scripts for pulling **usage metrics** (engagement) and
+**billing metrics** (cost) out of Copilot on a daily schedule and dropping the
+results into your own data lake.
+
+> **Two different things — don't confuse them:**
+> - **Usage metrics** = engagement/adoption data (active users, completions, chat). No dollar amounts.
+> - **Billing metrics** = consumption and cost data (AI Credits, quantities, dollar amounts).
+
+| Script | What it gives you | Auth |
+|--------|-------------------|------|
+| `copilot-usage-metrics.sh` | The pre-aggregated daily usage-metrics report (enterprise or org), as JSON | Enterprise GitHub App *(or PAT with `read:enterprise`)* |
+| `copilot-billing-export.sh` | The `ai_credit` billing CSV — every user, day, and model with dollar amounts | Classic PAT with `manage_billing:enterprise` |
+| `collect-daily.sh` | Runs both for the prior day and writes timestamped files to an output dir | Both of the above |
+| `generate-installation-token.sh` | Mints a short-lived GitHub App installation token (used internally by the usage script) | App private key |
+
+See [enterprise-setup.md](./enterprise-setup.md) for the one-time setup of the
+Enterprise GitHub App and the billing PAT.
+
+---
+
+## Why two auth mechanisms?
+
+GitHub Apps and fine-grained PATs **cannot access billing endpoints** — billing
+requires a classic PAT with `manage_billing:enterprise`, held by an enterprise
+owner or billing manager. Usage metrics, on the other hand, work great with an
+Enterprise GitHub App (higher rate limit, short-lived tokens). So the two domains
+use two tokens by design.
+
+| | Usage metrics | Billing |
+|---|---|---|
+| Endpoint family | `/enterprises/{ent}/copilot/metrics/reports/...` | `/enterprises/{ent}/settings/billing/reports` |
+| GitHub App | ✅ *View Enterprise Copilot Metrics* | ❌ not supported |
+| Fine-grained PAT | ⚠️ permission exists in docs, not yet in UI | ❌ not supported |
+| Classic PAT scope | `read:enterprise` or `manage_billing:copilot` | `manage_billing:enterprise` |
+
+---
+
+## Minimizing API calls
+
+Both scripts use the **pre-aggregated report** endpoints, not per-entity loops:
+
+- **Usage:** one report request returns a signed `download_links` URL; the script
+  downloads the NDJSON. **~2 calls/run.**
+- **Billing:** the bulk CSV export returns *every* user/day/model in one file via
+  create → poll → download. **~3–5 calls/run** instead of one call per user.
+
+A full daily collection is well under ten API calls — run it once a day against
+the prior complete UTC day.
+
+---
+
+## copilot-usage-metrics.sh
+
+Pulls the daily Copilot usage-metrics report. Enterprise-level by default; pass
+`--org` for organization-level.
+
+**APIs used** — each returns `download_links` to an NDJSON report the script then
+downloads. Reference page: [Copilot usage metrics](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics).
+
+For daily collection, use the **single-day** report:
+
+| Report | Endpoint | Docs |
+|--------|----------|------|
+| Enterprise, single day | `GET /enterprises/{ent}/copilot/metrics/reports/enterprise-1-day?day=YYYY-MM-DD` | [link](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics#get-copilot-enterprise-usage-metrics-for-a-specific-day) |
+| Org, single day | `GET /orgs/{org}/copilot/metrics/reports/organization-1-day?day=YYYY-MM-DD` | [link](https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics#get-copilot-organization-usage-metrics-for-a-specific-day) |
+
+```bash
+# Enterprise, yesterday (default), GitHub App auth
+source ~/.config/copilot-metrics/config
+./copilot-usage-metrics.sh my-enterprise \
+  --app-id "$APP_ID" --installation-id "$INSTALLATION_ID" --private-key "$PRIVATE_KEY"
+
+# A specific day
+./copilot-usage-metrics.sh my-enterprise --day 2026-06-21
+
+# Org-level instead (PAT or App with org metrics access)
+GH_TOKEN=$(gh auth token) ./copilot-usage-metrics.sh octodemo --org --day 2026-06-21
+```
+
+> The script also supports `--28day` (the `enterprise-28-day/latest` /
+> `organization-28-day/latest` endpoints) for a quick ad-hoc rolling snapshot or
+> an initial backfill. You don't need it for the daily job: once you're archiving
+> the single-day files, you rebuild any window from your own data.
+
+Requires the **Copilot usage metrics** policy to be **Enabled everywhere** for
+the enterprise. Output is JSON: request metadata plus a `report` array of the
+NDJSON rows. Progress goes to stderr, so `> file.json` captures clean output.
+
+---
+
+## copilot-billing-export.sh
+
+Exports AI Credit billing data via the bulk CSV report — the only way to get
+per-user data (with `username`, `total_monthly_quota`, `cost_center_name`)
+without one API call per known user.
+
+**Flow (3 API calls):**
+
+| Step | Endpoint | Docs |
+|------|----------|------|
+| 1. Create the report | `POST /enterprises/{ent}/settings/billing/reports` | [Create a usage report export](https://docs.github.com/en/enterprise-cloud@latest/rest/billing/usage-reports?apiVersion=2026-03-10#create-a-usage-report-export) |
+| 2. Poll until `completed` | `GET /enterprises/{ent}/settings/billing/reports/{id}` | [Get a usage report export](https://docs.github.com/en/enterprise-cloud@latest/rest/billing/usage-reports?apiVersion=2026-03-10#get-a-usage-report-export) |
+| 3. Download CSV | signed `download_urls[0]` (expires ~1h) | — |
+
+Reference page: [REST API endpoints for usage reports](https://docs.github.com/en/enterprise-cloud@latest/rest/billing/usage-reports?apiVersion=2026-03-10).
+
+```bash
+# Yesterday's ai_credit export → CSV on stdout
+export GH_BILLING_TOKEN=ghp_xxx   # classic PAT, manage_billing:enterprise
+./copilot-billing-export.sh my-enterprise > billing.csv
+
+# A date range, written straight to a file
+./copilot-billing-export.sh my-enterprise \
+  --start 2026-06-01 --end 2026-06-21 --out june-billing.csv
+```
+
+**CSV columns (`ai_credit`):** `date`, `username`, `product`, `sku`, `model`,
+`quantity`, `unit_type`, `applied_cost_per_quantity`, `gross_amount`,
+`discount_amount`, `net_amount`, `total_monthly_quota`, `organization`,
+`repository`, `cost_center_name`, `aic_quantity`, `aic_gross_amount`.
+
+Only one report runs at a time per enterprise — a `409` means another export is
+still in progress. Download URLs expire in ~1 hour, so fetch immediately (the
+script does).
+
+---
+
+## collect-daily.sh
+
+Runs both scripts for the prior day and writes timestamped files to an output
+directory — the hand-off point to your data lake.
+
+```bash
+source ~/.config/copilot-metrics/config
+export GH_BILLING_TOKEN=ghp_xxx
+
+./collect-daily.sh my-enterprise \
+  --out-dir ./copilot-data \
+  --app-id "$APP_ID" --installation-id "$INSTALLATION_ID" --private-key "$PRIVATE_KEY"
+```
+
+Produces:
+
+```
+copilot-data/usage-enterprise-my-enterprise-2026-06-21.json
+copilot-data/billing-ai_credit-my-enterprise-2026-06-21.csv
+```
+
+Sync that directory to object storage with whatever you already use (the script
+prints these as commented examples):
+
+```bash
+aws s3 cp ./copilot-data s3://my-bucket/copilot/2026-06-21/ --recursive   # AWS
+az storage blob upload-batch -d copilot/2026-06-21 -s ./copilot-data       # Azure
+gcloud storage cp ./copilot-data/* gs://my-bucket/copilot/2026-06-21/      # GCS
+```
+
+---
+
+## generate-installation-token.sh
+
+Mints a short-lived (1-hour) GitHub App installation token from a private key.
+Called internally by `copilot-usage-metrics.sh` when `--app-id` is provided; can
+also be run standalone.
+
+```bash
+./generate-installation-token.sh \
+  --app-id 12345 --installation-id 67890 \
+  --private-key ~/.config/copilot-metrics/app.pem
+```
+
+**API used:** `POST /app/installations/{installation_id}/access_tokens`. Requires
+`openssl`, `curl`, and `jq`.
+
+---
+
+## Requirements
+
+`bash`, `curl`, `jq`, and (for App auth) `openssl`. The scripts target
+`api.github.com` (GitHub Enterprise Cloud). Use API version `2026-03-10` for
+billing endpoints — the scripts set this header for you.

--- a/copilot-metrics-billing/enterprise-setup.md
+++ b/copilot-metrics-billing/enterprise-setup.md
@@ -1,0 +1,148 @@
+# Setup: Copilot Metrics & Billing Collection
+
+Two one-time setups, because the two data domains use two different tokens:
+
+1. **Enterprise GitHub App** — for **usage metrics** (engagement data). Higher
+   rate limit (15,000 req/hr) and short-lived tokens.
+2. **Billing-manager classic PAT** — for **billing metrics** (cost data). GitHub
+   Apps and fine-grained PATs cannot access billing endpoints.
+
+---
+
+## Prerequisites
+
+- **Enterprise owner** access (to create the App and the billing PAT, and to
+  enable the usage-metrics policy).
+- `openssl`, `curl`, and `jq` installed locally (all pre-installed or easily
+  available on macOS/Linux).
+
+---
+
+## Part 1 — Enterprise GitHub App (usage metrics)
+
+### Step 1: Enable the usage-metrics policy
+
+The metrics endpoints return data only when the **Copilot usage metrics** policy
+is set to **Enabled everywhere** for the enterprise.
+
+1. Go to your enterprise: **Settings → Policies → Copilot**.
+2. Set **Copilot usage metrics** to **Enabled everywhere**.
+
+See [Manage enterprise policies for Copilot](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/administer-copilot/manage-for-enterprise/manage-enterprise-policies).
+
+### Step 2: Create the GitHub App
+
+1. Go to: **`https://github.com/enterprises/<your-enterprise>/settings/apps/new`**
+2. Fill in the form:
+
+   | Field | Value |
+   |-------|-------|
+   | **GitHub App name** | `Copilot Metrics Collector` |
+   | **Homepage URL** | any URL you control |
+
+3. Under **Webhook**: **uncheck** "Active" (no webhook events needed).
+
+4. Under **Permissions → Enterprise permissions**:
+   - **View Enterprise Copilot Metrics**: Read-only
+
+   > If you also want **org-level** reports (the `--org` flag), add
+   > **Organization permissions → Organization Copilot metrics: Read-only** as well.
+
+5. Under **Where can this GitHub App be installed?**: **Only on this account**.
+
+6. Click **Create GitHub App**, then **note the App ID** on the next page.
+
+### Step 3: Generate a private key
+
+1. On the App settings page, scroll to **Private keys → Generate a private key**.
+2. A `.pem` file downloads. Move it somewhere safe:
+
+```bash
+mkdir -p ~/.config/copilot-metrics
+mv ~/Downloads/copilot-metrics-collector.*.pem ~/.config/copilot-metrics/app.pem
+chmod 600 ~/.config/copilot-metrics/app.pem
+```
+
+### Step 4: Install the App on the enterprise
+
+1. From the App settings, click **Install App** and install it on your enterprise.
+2. **Note the Installation ID** from the URL:
+   `.../settings/installations/<INSTALLATION_ID>`.
+
+### Step 5: Store the App config
+
+```bash
+cat > ~/.config/copilot-metrics/config << 'EOF'
+APP_ID=<your-app-id>
+INSTALLATION_ID=<your-installation-id>
+PRIVATE_KEY=~/.config/copilot-metrics/app.pem
+EOF
+```
+
+Test it:
+
+```bash
+source ~/.config/copilot-metrics/config
+./scripts/copilot-usage-metrics.sh <your-enterprise> \
+  --app-id "$APP_ID" --installation-id "$INSTALLATION_ID" --private-key "$PRIVATE_KEY" \
+  | jq '.report_meta'
+```
+
+> If you get `Resource not accessible by integration`, the App is missing the
+> **View Enterprise Copilot Metrics** permission, or the usage-metrics policy
+> isn't enabled yet. Fix it, then re-accept the updated permissions on the
+> installation.
+
+---
+
+## Part 2 — Billing-manager PAT (billing metrics)
+
+Billing endpoints require a **classic** personal access token with the
+`manage_billing:enterprise` scope, owned by an **enterprise owner or billing
+manager**. There is no GitHub App or fine-grained PAT equivalent today.
+
+1. Go to: **`https://github.com/settings/tokens`** → **Generate new token
+   (classic)**.
+2. Select the **`manage_billing:enterprise`** scope.
+3. Generate the token and store it as an environment variable (kept separate from
+   the App token):
+
+```bash
+export GH_BILLING_TOKEN=ghp_xxxxxxxxxxxxxxxx
+```
+
+Test it:
+
+```bash
+./scripts/copilot-billing-export.sh <your-enterprise> --out /tmp/billing.csv
+head -1 /tmp/billing.csv
+```
+
+> A `404` on the `/reports` endpoints means the token is missing
+> `manage_billing:enterprise`. The other billing endpoints (`/usage/summary`,
+> `/ai_credit/usage`) work with just the enterprise role, but the bulk CSV export
+> needs this scope.
+
+---
+
+## Rate limits
+
+| Auth method | Rate limit |
+|-------------|-----------|
+| Classic PAT | 5,000 req/hr |
+| GitHub App (installation token) | 15,000 req/hr |
+
+A full daily collection is under ten API calls, so either budget is plenty — but
+the App is the better choice for usage metrics because of the short-lived tokens.
+
+---
+
+## Security notes
+
+- The App private key and the billing PAT **never** go into the repository.
+- Installation tokens expire after **1 hour**; billing download URLs expire in
+  **~1 hour**.
+- Both tokens are **read-only** with respect to your code — they cannot modify
+  repositories or PRs.
+- If a credential is compromised, revoke it (App settings for the key, token
+  settings for the PAT) and reissue.

--- a/copilot-metrics-billing/scripts/collect-daily.sh
+++ b/copilot-metrics-billing/scripts/collect-daily.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# collect-daily.sh
+# Orchestrator: runs the usage-metrics and billing-export scripts for the prior
+# day and drops timestamped files into an output directory — the hand-off point
+# to your data lake. Sync that directory to S3 / Azure Blob / GCS with whatever
+# you already use (see the one-liners at the bottom of this file).
+#
+# Usage: ./collect-daily.sh <enterprise> [options]
+#
+# Options:
+#   --day YYYY-MM-DD     Day to collect (default: yesterday, UTC).
+#   --out-dir DIR        Output directory (default: ./copilot-data).
+#   --org SLUG           Also/instead pull org-level usage metrics for SLUG.
+#                        (Omit to pull enterprise-level usage metrics.)
+#   --skip-usage         Don't pull usage metrics.
+#   --skip-billing       Don't pull billing data.
+#   --app-id ID          GitHub App ID for usage metrics (passed through).
+#   --installation-id ID GitHub App Installation ID (passed through).
+#   --private-key PATH   GitHub App private key (passed through).
+#
+# Auth:
+#   - Usage metrics: GitHub App (preferred) or GH_TOKEN (read:enterprise).
+#   - Billing:       GH_BILLING_TOKEN (classic PAT w/ manage_billing:enterprise).
+#
+# Output files (in --out-dir):
+#   usage-<scope>-<slug>-<day>.json
+#   billing-ai_credit-<enterprise>-<day>.csv
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ENTERPRISE="${1:?Usage: $0 <enterprise> [--day YYYY-MM-DD] [--out-dir DIR] [--org SLUG] [--skip-usage] [--skip-billing] [App flags]}"
+shift
+
+DAY=""
+OUT_DIR="./copilot-data"
+ORG=""
+SKIP_USAGE=""
+SKIP_BILLING=""
+APP_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --day) DAY="$2"; shift 2 ;;
+    --out-dir) OUT_DIR="$2"; shift 2 ;;
+    --org) ORG="$2"; shift 2 ;;
+    --skip-usage) SKIP_USAGE="1"; shift ;;
+    --skip-billing) SKIP_BILLING="1"; shift ;;
+    --app-id) APP_ARGS+=(--app-id "$2"); shift 2 ;;
+    --installation-id) APP_ARGS+=(--installation-id "$2"); shift 2 ;;
+    --private-key) APP_ARGS+=(--private-key "$2"); shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$DAY" ]]; then
+  DAY=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "1 day ago" +%Y-%m-%d)
+fi
+
+mkdir -p "$OUT_DIR"
+echo "Collecting Copilot data for $DAY into $OUT_DIR" >&2
+
+# --- Usage metrics ---
+if [[ -z "$SKIP_USAGE" ]]; then
+  if [[ -n "$ORG" ]]; then
+    USAGE_OUT="$OUT_DIR/usage-org-$ORG-$DAY.json"
+    echo "-> usage metrics (org: $ORG)" >&2
+    "$SCRIPT_DIR/copilot-usage-metrics.sh" "$ORG" --org --day "$DAY" "${APP_ARGS[@]}" > "$USAGE_OUT"
+  else
+    USAGE_OUT="$OUT_DIR/usage-enterprise-$ENTERPRISE-$DAY.json"
+    echo "-> usage metrics (enterprise: $ENTERPRISE)" >&2
+    "$SCRIPT_DIR/copilot-usage-metrics.sh" "$ENTERPRISE" --day "$DAY" "${APP_ARGS[@]}" > "$USAGE_OUT"
+  fi
+  echo "   wrote $USAGE_OUT" >&2
+fi
+
+# --- Billing ---
+if [[ -z "$SKIP_BILLING" ]]; then
+  BILLING_OUT="$OUT_DIR/billing-ai_credit-$ENTERPRISE-$DAY.csv"
+  echo "-> billing export (enterprise: $ENTERPRISE)" >&2
+  "$SCRIPT_DIR/copilot-billing-export.sh" "$ENTERPRISE" \
+    --start "$DAY" --end "$DAY" --out "$BILLING_OUT"
+  echo "   wrote $BILLING_OUT" >&2
+fi
+
+echo "Done. Files ready in $OUT_DIR/" >&2
+
+# --- Ship to your data lake (pick one, run from your scheduler) -------------
+# AWS S3:     aws s3 cp "$OUT_DIR" "s3://my-bucket/copilot/$DAY/" --recursive
+# Azure Blob: az storage blob upload-batch -d "copilot/$DAY" -s "$OUT_DIR"
+# GCS:        gcloud storage cp "$OUT_DIR/*" "gs://my-bucket/copilot/$DAY/"

--- a/copilot-metrics-billing/scripts/copilot-billing-export.sh
+++ b/copilot-metrics-billing/scripts/copilot-billing-export.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# copilot-billing-export.sh
+# Daily job: exports Copilot BILLING data (AI Credit consumption — per user, per
+# day, per model, with dollar amounts) for an enterprise via the bulk CSV export.
+#
+# Why the CSV export instead of /ai_credit/usage?
+#   - One export returns EVERY user / day / model in a single file (3 API calls:
+#     create -> poll -> download), including fields the JSON API can't give you
+#     per-user without one call per known username (e.g. `username`,
+#     `total_monthly_quota`, `cost_center_name`).
+#
+# Auth: classic PAT with the `manage_billing:enterprise` scope, held by an
+#       enterprise owner or billing manager. GitHub Apps and fine-grained PATs
+#       CANNOT access billing endpoints — that's why billing uses a separate PAT.
+#
+# Usage: ./copilot-billing-export.sh <enterprise> [options]
+#
+# Options:
+#   --start YYYY-MM-DD   Start date (default: yesterday, UTC).
+#   --end YYYY-MM-DD     End date   (default: yesterday, UTC).
+#   --report-type TYPE   ai_credit (default) | premium_request | detailed | summarized
+#   --out PATH           Write the CSV to PATH instead of stdout.
+#   --poll-timeout SECS  Max seconds to wait for the report (default: 300).
+#
+# Auth priority:
+#   1. GH_BILLING_TOKEN env var (preferred — keep the billing PAT separate)
+#   2. GH_TOKEN env var
+#   3. `gh auth token` fallback
+#
+# Output: CSV to stdout (or --out). Progress/debug to stderr.
+
+set -euo pipefail
+
+API_VERSION="2026-03-10"
+
+ENTERPRISE="${1:?Usage: $0 <enterprise> [--start YYYY-MM-DD] [--end YYYY-MM-DD] [--report-type ai_credit] [--out PATH] [--poll-timeout SECS]}"
+shift
+
+START=""
+END=""
+REPORT_TYPE="ai_credit"
+OUT=""
+POLL_TIMEOUT=300
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --start) START="$2"; shift 2 ;;
+    --end) END="$2"; shift 2 ;;
+    --report-type) REPORT_TYPE="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --poll-timeout) POLL_TIMEOUT="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+YESTERDAY=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "1 day ago" +%Y-%m-%d)
+START="${START:-$YESTERDAY}"
+END="${END:-$YESTERDAY}"
+
+# Auth: prefer a dedicated billing token so it never gets mixed up with the
+# GitHub App / metrics token.
+if [[ -n "${GH_BILLING_TOKEN:-}" ]]; then
+  TOKEN="$GH_BILLING_TOKEN"
+elif [[ -n "${GH_TOKEN:-}" ]]; then
+  TOKEN="$GH_TOKEN"
+else
+  TOKEN=$(gh auth token 2>/dev/null || true)
+fi
+
+if [[ -z "${TOKEN:-}" ]]; then
+  echo "ERROR: No auth token. Set GH_BILLING_TOKEN (classic PAT w/ manage_billing:enterprise)." >&2
+  exit 1
+fi
+
+api() {
+  curl -sS -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-GitHub-Api-Version: $API_VERSION" \
+    "$@"
+}
+
+BASE="https://api.github.com/enterprises/$ENTERPRISE/settings/billing/reports"
+
+# 1. Create the report (returns 202 + an id). Only one report runs at a time per
+#    enterprise — a 409 means another export is still in progress.
+echo "Creating $REPORT_TYPE billing report for $ENTERPRISE ($START -> $END)..." >&2
+CREATE=$(api -X POST "$BASE" \
+  -d "{\"report_type\":\"$REPORT_TYPE\",\"start_date\":\"$START\",\"end_date\":\"$END\"}")
+
+REPORT_ID=$(echo "$CREATE" | jq -r '.id // empty')
+if [[ -z "$REPORT_ID" ]]; then
+  echo "ERROR: Could not create report: $CREATE" >&2
+  echo "  (A 409 means another export is already running. The PAT needs manage_billing:enterprise.)" >&2
+  exit 1
+fi
+echo "Report queued (id: $REPORT_ID). Polling..." >&2
+
+# 2. Poll until status == completed (typically ~90s).
+DEADLINE=$(( $(date +%s) + POLL_TIMEOUT ))
+DOWNLOAD_URL=""
+while :; do
+  STATUS_JSON=$(api "$BASE/$REPORT_ID")
+  STATUS=$(echo "$STATUS_JSON" | jq -r '.status // empty')
+  case "$STATUS" in
+    completed)
+      DOWNLOAD_URL=$(echo "$STATUS_JSON" | jq -r '.download_urls[0] // empty')
+      break ;;
+    failed)
+      echo "ERROR: Report generation failed: $STATUS_JSON" >&2
+      exit 1 ;;
+    "")
+      echo "ERROR: Unexpected poll response: $STATUS_JSON" >&2
+      exit 1 ;;
+  esac
+  if [[ $(date +%s) -ge $DEADLINE ]]; then
+    echo "ERROR: Timed out after ${POLL_TIMEOUT}s waiting for report $REPORT_ID (status: $STATUS)." >&2
+    exit 1
+  fi
+  sleep 10
+done
+
+if [[ -z "$DOWNLOAD_URL" ]]; then
+  echo "ERROR: Report completed but no download_urls were returned." >&2
+  exit 1
+fi
+
+# 3. Download the CSV (signed URL, expires in ~1 hour — fetch immediately).
+echo "Downloading CSV..." >&2
+if [[ -n "$OUT" ]]; then
+  curl -sS -o "$OUT" "$DOWNLOAD_URL"
+  echo "Wrote $OUT" >&2
+else
+  curl -sS "$DOWNLOAD_URL"
+fi

--- a/copilot-metrics-billing/scripts/copilot-billing-export.sh
+++ b/copilot-metrics-billing/scripts/copilot-billing-export.sh
@@ -83,9 +83,15 @@ BASE="https://api.github.com/enterprises/$ENTERPRISE/settings/billing/reports"
 
 # 1. Create the report (returns 202 + an id). Only one report runs at a time per
 #    enterprise — a 409 means another export is still in progress.
+#    The payload is built with jq so quotes/odd characters in the inputs can't
+#    break the JSON or inject extra fields.
 echo "Creating $REPORT_TYPE billing report for $ENTERPRISE ($START -> $END)..." >&2
-CREATE=$(api -X POST "$BASE" \
-  -d "{\"report_type\":\"$REPORT_TYPE\",\"start_date\":\"$START\",\"end_date\":\"$END\"}")
+PAYLOAD=$(jq -n \
+  --arg report_type "$REPORT_TYPE" \
+  --arg start_date "$START" \
+  --arg end_date "$END" \
+  '{report_type: $report_type, start_date: $start_date, end_date: $end_date}')
+CREATE=$(api -X POST "$BASE" -H "Content-Type: application/json" -d "$PAYLOAD")
 
 REPORT_ID=$(echo "$CREATE" | jq -r '.id // empty')
 if [[ -z "$REPORT_ID" ]]; then

--- a/copilot-metrics-billing/scripts/copilot-usage-metrics.sh
+++ b/copilot-metrics-billing/scripts/copilot-usage-metrics.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# copilot-usage-metrics.sh
+# Daily job: pulls the pre-aggregated Copilot USAGE metrics report (engagement
+# data — active users, completions, chat, etc.) for an enterprise or org and
+# writes it as JSON to stdout. Usage metrics contain NO billing amounts.
+#
+# It calls the "report" endpoint, which returns short-lived download_links to an
+# NDJSON file, then downloads and emits that file. ~2 API calls per run.
+#
+# Usage: ./copilot-usage-metrics.sh <enterprise> [options]
+#        ./copilot-usage-metrics.sh <org> --org [options]
+#
+# Options:
+#   --org                    Treat the slug as an ORG (organization-1-day) instead
+#                            of an enterprise (enterprise-1-day, the default).
+#   --day YYYY-MM-DD         Day to pull (default: yesterday, UTC).
+#   --28day                  Pull the 28-day rolling report instead of a single day.
+#                            NOT needed for the daily archive job: once you're
+#                            storing the single-day files you can rebuild any
+#                            window yourself. Use it only for an ad-hoc rolling
+#                            snapshot or an initial backfill.
+#   --app-id ID              GitHub App ID (enables App auth — enterprise App with
+#                            the "View Enterprise Copilot Metrics" permission).
+#   --installation-id ID     GitHub App Installation ID.
+#   --private-key PATH       Path to GitHub App private key (.pem).
+#
+# Auth priority:
+#   1. GitHub App (if --app-id, --installation-id, --private-key all provided)
+#   2. GH_TOKEN env var (classic PAT needs manage_billing:copilot or read:enterprise)
+#   3. `gh auth token` fallback
+#
+# Output: JSON (the downloaded report, wrapped with request metadata) to stdout.
+#         Progress/debug to stderr.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+API_VERSION="2026-03-10"
+
+SLUG="${1:?Usage: $0 <enterprise|org> [--org] [--day YYYY-MM-DD] [--28day] [--app-id ID --installation-id ID --private-key PATH]}"
+shift
+
+# Parse optional flags
+SCOPE="enterprise"
+DAY=""
+ROLLING=""
+APP_ID=""
+INSTALLATION_ID=""
+PRIVATE_KEY=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --org) SCOPE="org"; shift ;;
+    --day) DAY="$2"; shift 2 ;;
+    --28day) ROLLING="1"; shift ;;
+    --app-id) APP_ID="$2"; shift 2 ;;
+    --installation-id) INSTALLATION_ID="$2"; shift 2 ;;
+    --private-key) PRIVATE_KEY="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# Default day: yesterday (UTC) — the most recent complete day.
+if [[ -z "$DAY" ]]; then
+  DAY=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "1 day ago" +%Y-%m-%d)
+fi
+
+# Auth setup
+if [[ -n "$APP_ID" && -n "$INSTALLATION_ID" && -n "$PRIVATE_KEY" ]]; then
+  echo "Authenticating via GitHub App (App ID: $APP_ID)..." >&2
+  TOKEN=$("$SCRIPT_DIR/generate-installation-token.sh" \
+    --app-id "$APP_ID" \
+    --installation-id "$INSTALLATION_ID" \
+    --private-key "$PRIVATE_KEY")
+  if [[ -z "$TOKEN" ]]; then
+    echo "ERROR: Failed to generate installation token." >&2
+    exit 1
+  fi
+  echo "Installation token acquired (expires in 1 hour)." >&2
+elif [[ -n "${GH_TOKEN:-}" ]]; then
+  TOKEN="$GH_TOKEN"
+else
+  TOKEN=$(gh auth token 2>/dev/null || true)
+fi
+
+if [[ -z "${TOKEN:-}" ]]; then
+  echo "ERROR: No auth token. Set GH_TOKEN, run 'gh auth login', or pass App credentials." >&2
+  exit 1
+fi
+
+# Build the report endpoint URL
+if [[ "$SCOPE" == "org" ]]; then
+  if [[ -n "$ROLLING" ]]; then
+    REPORT_PATH="/orgs/$SLUG/copilot/metrics/reports/organization-28-day/latest"
+  else
+    REPORT_PATH="/orgs/$SLUG/copilot/metrics/reports/organization-1-day?day=$DAY"
+  fi
+else
+  if [[ -n "$ROLLING" ]]; then
+    REPORT_PATH="/enterprises/$SLUG/copilot/metrics/reports/enterprise-28-day/latest"
+  else
+    REPORT_PATH="/enterprises/$SLUG/copilot/metrics/reports/enterprise-1-day?day=$DAY"
+  fi
+fi
+
+echo "Requesting usage metrics report: $REPORT_PATH" >&2
+
+api() {
+  curl -sS -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "X-GitHub-Api-Version: $API_VERSION" \
+    "$@"
+}
+
+RESPONSE=$(api "https://api.github.com${REPORT_PATH}")
+
+# Surface API errors clearly
+if echo "$RESPONSE" | jq -e '.message? // empty' >/dev/null 2>&1; then
+  echo "ERROR: API returned: $(echo "$RESPONSE" | jq -r '.message')" >&2
+  echo "  (Check the 'Copilot usage metrics' policy is enabled and the token has the right permission.)" >&2
+  exit 1
+fi
+
+# Pull the first download link (signed, short-lived) and fetch the NDJSON report.
+LINK=$(echo "$RESPONSE" | jq -r '.download_links[0] // empty')
+if [[ -z "$LINK" ]]; then
+  echo "ERROR: No download_links in response: $RESPONSE" >&2
+  exit 1
+fi
+
+echo "Downloading report file..." >&2
+REPORT_NDJSON=$(curl -sS "$LINK")
+
+# Emit a single JSON object: request metadata + the report rows as an array.
+# NDJSON rows are slurped into .report; empty lines are ignored.
+jq -n \
+  --arg scope "$SCOPE" \
+  --arg slug "$SLUG" \
+  --arg day "$DAY" \
+  --argjson rolling "$([[ -n "$ROLLING" ]] && echo true || echo false)" \
+  --argjson meta "$(echo "$RESPONSE" | jq '{report_day, report_start_day, report_end_day}')" \
+  --slurpfile rows <(echo "$REPORT_NDJSON" | jq -c 'select(length>0)') \
+  '{scope: $scope, slug: $slug, day: $day, rolling: $rolling, report_meta: $meta, report: $rows}'

--- a/copilot-metrics-billing/scripts/copilot-usage-metrics.sh
+++ b/copilot-metrics-billing/scripts/copilot-usage-metrics.sh
@@ -128,16 +128,17 @@ if [[ -z "$LINK" ]]; then
   exit 1
 fi
 
-echo "Downloading report file..." >&2
-REPORT_NDJSON=$(curl -sS "$LINK")
+echo "Downloading and assembling report file..." >&2
 
 # Emit a single JSON object: request metadata + the report rows as an array.
-# NDJSON rows are slurped into .report; empty lines are ignored.
+# We stream the download straight into jq (no intermediate shell variable) so
+# large reports aren't held in memory twice and the raw bytes aren't reinterpreted
+# by echo. NDJSON rows are slurped into .report; empty lines are ignored.
 jq -n \
   --arg scope "$SCOPE" \
   --arg slug "$SLUG" \
   --arg day "$DAY" \
   --argjson rolling "$([[ -n "$ROLLING" ]] && echo true || echo false)" \
   --argjson meta "$(echo "$RESPONSE" | jq '{report_day, report_start_day, report_end_day}')" \
-  --slurpfile rows <(echo "$REPORT_NDJSON" | jq -c 'select(length>0)') \
+  --slurpfile rows <(curl -sS "$LINK" | jq -c 'select(length>0)') \
   '{scope: $scope, slug: $slug, day: $day, rolling: $rolling, report_meta: $meta, report: $rows}'

--- a/copilot-metrics-billing/scripts/generate-installation-token.sh
+++ b/copilot-metrics-billing/scripts/generate-installation-token.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# generate-installation-token.sh
+# Generates a GitHub App installation token from a private key.
+# Requires: openssl, curl, jq (all pre-installed or easily available on macOS/Linux).
+#
+# Usage:
+#   ./generate-installation-token.sh --app-id 12345 --installation-id 67890 --private-key path/to/key.pem
+#
+# Output: Installation token to stdout (use as GH_TOKEN)
+
+set -euo pipefail
+
+# Parse arguments
+APP_ID=""
+INSTALLATION_ID=""
+PRIVATE_KEY_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app-id) APP_ID="$2"; shift 2 ;;
+    --installation-id) INSTALLATION_ID="$2"; shift 2 ;;
+    --private-key) PRIVATE_KEY_PATH="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; echo "Usage: $0 --app-id ID --installation-id ID --private-key PATH" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$APP_ID" || -z "$INSTALLATION_ID" || -z "$PRIVATE_KEY_PATH" ]]; then
+  echo "ERROR: --app-id, --installation-id, and --private-key are all required." >&2
+  exit 1
+fi
+
+if [[ ! -f "$PRIVATE_KEY_PATH" ]]; then
+  echo "ERROR: Private key not found: $PRIVATE_KEY_PATH" >&2
+  exit 1
+fi
+
+# --- Generate JWT ---
+# GitHub App JWTs are RS256-signed, valid for max 10 minutes.
+# We set iat to 60s ago (clock skew) and exp to 10 minutes from now.
+
+NOW=$(date +%s)
+IAT=$((NOW - 60))
+EXP=$((NOW + 600))
+
+# Base64url encode (no padding, URL-safe)
+b64url() {
+  openssl base64 -e -A | tr '+/' '-_' | tr -d '='
+}
+
+# JWT Header
+HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+
+# JWT Payload
+PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$IAT" "$EXP" "$APP_ID" | b64url)
+
+# Sign
+SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | \
+  openssl dgst -sha256 -sign "$PRIVATE_KEY_PATH" -binary | b64url)
+
+JWT="${HEADER}.${PAYLOAD}.${SIGNATURE}"
+
+# --- Exchange JWT for Installation Token ---
+RESPONSE=$(curl -s -X POST \
+  -H "Authorization: Bearer $JWT" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/app/installations/$INSTALLATION_ID/access_tokens")
+
+TOKEN=$(echo "$RESPONSE" | jq -r '.token // empty')
+
+if [[ -z "$TOKEN" ]]; then
+  echo "ERROR: Failed to get installation token." >&2
+  echo "Response: $RESPONSE" >&2
+  exit 1
+fi
+
+echo "$TOKEN"

--- a/index.md
+++ b/index.md
@@ -28,6 +28,7 @@ The highest-impact adoption strategies focus on raising the floor across your or
 The following pages cover topics not yet addressed by official documentation and remain actively maintained.
 
 - [Managing Copilot Usage-Based Billing](./cost-management)
+- [Pulling Copilot Metrics & Billing Into Your Data Lake](./copilot-metrics-billing)
 - [Measuring AI in Pull Requests](./ai-commit-attribution)
 - [Copilot OpenTelemetry via Intune](./copilot-otel-intune)
 


### PR DESCRIPTION
## Summary
- add a new Copilot metrics and billing guide for admins
- add example scripts to pull usage metrics and billing exports daily into a data lake
- document GitHub App and billing PAT setup for the required auth flows

## Testing
- bash -n on the new shell scripts
- verified the new guide links and docs URLs
